### PR TITLE
Bump Node version to fix CVE. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as a parent image
-FROM node:20-alpine
+FROM node:20.20.0-alpine
 
 # Set the working directory in the container
 WORKDIR /app

--- a/docs/CROP_CATEGORY_ASSIGNMENTS.md
+++ b/docs/CROP_CATEGORY_ASSIGNMENTS.md
@@ -464,3 +464,4 @@ This document lists all crops assigned to each feedstock category with their cha
 3. **Energy values** are on dry basis
 4. **Processing suitability** based on scientific research and industry standards
 5. Some crops fit multiple uses (e.g., alfalfa can be used for AD, combustion, or bedding)
+

--- a/docs/PROCESSING_SUITABILITY_FIX.md
+++ b/docs/PROCESSING_SUITABILITY_FIX.md
@@ -140,3 +140,4 @@ The processing suitability assignments are based on:
 ✅ Compiles successfully
 ✅ No TypeScript errors
 ✅ Ready for testing
+


### PR DESCRIPTION
updated the Dockerfile to use the Node.js version 20.20.0-alpine as requested to address the critical vulnerability (CVE-2025-55130).

The following changes were made:

- Updated `Dockerfile`: Changed base image from `node:20-alpine` to `node:20.20.0-alpine`.

This ensures that when the application is rebuilt and deployed to Google Cloud Run, it will use the patched Node.js version.

No other files (cloudbuild configuration or package.json) required changes as they rely on the Dockerfile for the runtime environment.
