### PR TITLE
fix: assign dedicated Cloud Run SA instead of Compute Engine default SA

### DIFF
--- a/cloudbuild-prod.yaml
+++ b/cloudbuild-prod.yaml
@@ -47,6 +47,8 @@ steps:
       - '--platform'
       - 'managed'
       - '--allow-unauthenticated'
+      - '--service-account'
+      - 'biocirv-prod-cr-frontend@biocirv-470318.iam.gserviceaccount.com'
       - '--set-env-vars'
       - 'ENVIRONMENT=${_ENVIRONMENT},CA_BIOSITE_API_USER=cal-bioscape-frontend-prod,NEXT_PUBLIC_API_BASE_URL=https://api.calbioscape.org,GITHUB_ISSUE_CREATE_ENABLED=true,GITHUB_REPO_OWNER=sustainability-software-lab,GITHUB_REPO_NAME=cal-bioscape-frontend'
       - '--update-secrets'

--- a/cloudbuild-staging.yaml
+++ b/cloudbuild-staging.yaml
@@ -47,6 +47,8 @@ steps:
       - '--platform'
       - 'managed'
       - '--allow-unauthenticated'
+      - '--service-account'
+      - 'biocirv-staging-cr-frontend@biocirv-470318.iam.gserviceaccount.com'
       - '--set-env-vars'
       - 'ENVIRONMENT=${_ENVIRONMENT},CA_BIOSITE_API_USER=cal-bioscape-frontend,NEXT_PUBLIC_API_BASE_URL=https://api-staging.calbioscape.org,GITHUB_ISSUE_CREATE_ENABLED=true,GITHUB_REPO_OWNER=sustainability-software-lab,GITHUB_REPO_NAME=cal-bioscape-frontend'
       - '--update-secrets'


### PR DESCRIPTION
## Summary

The `cal-bioscape-frontend` Cloud Run service was running as the **Compute Engine default service account**, which carries `roles/editor` by default — project-wide write access on a public-facing Next.js app. This was flagged by Wiz as a critical privilege violation (forwarded from Aashish's email thread on least-privilege remediation).

This PR assigns a dedicated SA with the minimum required permissions.

### Changes

| File | Change |
|---|---|
| `cloudbuild-staging.yaml` | Add `--service-account biocirv-staging-cr-frontend@biocirv-470318.iam.gserviceaccount.com` |
| `cloudbuild-prod.yaml` | Add `--service-account biocirv-prod-cr-frontend@biocirv-470318.iam.gserviceaccount.com` |

### Why only `secretmanager.secretAccessor`?

The new SA is granted only `roles/secretmanager.secretAccessor`. This is the minimum needed because:
- `CA_BIOSITE_API_PASSWORD` and `GITHUB_TOKEN` are read from Secret Manager via `--update-secrets` at deploy time
- Mapbox tokens are baked into the Docker image at build time via `--build-arg` — no runtime access needed
- The frontend calls the `biocirv-webservice` API; it does not connect to Cloud SQL or GCS directly

### Dependency — must merge AFTER `sustainability-software-lab/ca-biositing#249`

The new SA (`biocirv-{env}-cr-frontend`) is created by a companion Pulumi PR:
**[sustainability-software-lab/ca-biositing#249](https://github.com/sustainability-software-lab/ca-biositing/pull/249)**

**Do not merge this PR until:**
1. `ca-biositing#249` is merged
2. `pulumi up` has been run in the ca-biositing infra to create the SA in GCP
3. Verify the SA exists: `gcloud iam service-accounts describe biocirv-staging-cr-frontend@biocirv-470318.iam.gserviceaccount.com`

If Cloud Build runs before the SA exists, `gcloud run deploy` will fail with "service account not found." This is recoverable — just re-trigger Cloud Build after `pulumi up`.

## Test plan

- [ ] Merge `ca-biositing#249` and run `pulumi up --stack staging`
- [ ] Verify staging SA exists: `gcloud iam service-accounts describe biocirv-staging-cr-frontend@biocirv-470318.iam.gserviceaccount.com`
- [ ] Merge this PR — Cloud Build triggers automatically
- [ ] Confirm Cloud Build step `gcloud run deploy` succeeds (no "service account not found" error)
- [ ] Verify the deployed service uses the dedicated SA: `gcloud run services describe cal-bioscape-frontend-staging --region us-west1 --format="value(spec.template.spec.serviceAccountName)"`
- [ ] Verify the app serves correctly and secrets are accessible (staging.calbioscape.org loads, bug report modal works)
- [ ] Repeat for production after staging validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
