### PR TITLE
fix: rename SAF Plants label to Biorefineries

### DIFF
--- a/src/components/LayerControls.tsx
+++ b/src/components/LayerControls.tsx
@@ -816,7 +816,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                       </Label>
                     </div>
                     
-                    {/* SAF Plants Layer Toggle - Under Infrastructure */}
+                    {/* Biorefineries Layer Toggle - Under Infrastructure */}
                     <div className="flex items-center space-x-2 pl-6 mt-2">
                        <Checkbox
                         id="safPlants"
@@ -835,7 +835,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                             flexShrink: 0,
                           }}
                         ></span>
-                        Sustainable Aviation Fuel Plants
+                        Biorefineries
                       </Label>
                     </div>
                     

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -2566,7 +2566,7 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
           'biorefineries-layer': 'Biorefinery Details',
           'cement-plants-layer': 'Cement Plant Details',
           'mrf-layer': 'Material Recovery Facility Details',
-          'saf-plants-layer': 'Sustainable Aviation Fuel Plant Details',
+          'saf-plants-layer': 'Biorefinery Details',
           'renewable-diesel-layer': 'Renewable Diesel Plant Details',
           'landfill-lfg-layer': 'Landfill LFG Project Details',
           'wastewater-treatment-layer': 'Wastewater Treatment Plant Details',

--- a/src/lib/tileset-registry.ts
+++ b/src/lib/tileset-registry.ts
@@ -58,7 +58,7 @@ export const DEFAULT_TILESET_REGISTRY: Record<string, TilesetConfig> = {
   safPlants: {
     tilesetId: 'tylerhuntington222.6x05ytem', // TODO: Update to sustainasoft.cal-bioscape-nrel-saf-plants-YYYY-MM
     sourceLayer: 'renewable_diesel_saf_plants-79er6d', // TODO: Backend should use stable name: renewable_diesel_saf_plants
-    displayName: 'SAF Plants',
+    displayName: 'Biorefineries',
     category: 'infrastructure',
     version: 'current',
     accountType: 'legacy'

--- a/tests/tileset-registry.test.ts
+++ b/tests/tileset-registry.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { TILESET_REGISTRY } from '../src/lib/tileset-registry';
+
+test('safPlants displayName is Biorefineries, not SAF Plants', () => {
+  assert.equal(TILESET_REGISTRY.safPlants.displayName, 'Biorefineries');
+});
+
+test('safPlants displayName does not contain SAF', () => {
+  assert.ok(
+    !TILESET_REGISTRY.safPlants.displayName.includes('SAF'),
+    `Expected displayName not to contain 'SAF', got: ${TILESET_REGISTRY.safPlants.displayName}`
+  );
+});


### PR DESCRIPTION
closes #48

## What Changed

- **`src/lib/tileset-registry.ts`** — `displayName` for `safPlants` changed from `'SAF Plants'` to `'Biorefineries'`
- **`src/components/LayerControls.tsx`** — sidebar label changed from `Sustainable Aviation Fuel Plants` to `Biorefineries`
- **`src/components/Map.js`** — popup title changed from `Sustainable Aviation Fuel Plant Details` to `Biorefinery Details`
- **`tests/tileset-registry.test.ts`** — new tests verifying the displayName is `'Biorefineries'` and contains no `'SAF'`

Internal layer keys (`safPlants`, `saf-plants-layer`, `saf-plants-source`) are unchanged — only user-facing display strings were updated.