### PR TITLE
fix: add missing popup label mappings and tomatoProcessors layer state

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,6 +41,7 @@ export default function Home() {
     combustionPlants: false,
     districtEnergySystems: false,
     foodProcessors: false,
+    tomatoProcessors: false,
     foodRetailers: false,
     powerPlants: false,
     foodBanks: false,
@@ -95,6 +96,7 @@ export default function Home() {
            layerVisibility.combustionPlants ||
            layerVisibility.districtEnergySystems ||
            layerVisibility.foodProcessors ||
+           layerVisibility.tomatoProcessors ||
            layerVisibility.foodRetailers ||
            layerVisibility.powerPlants ||
            layerVisibility.foodBanks ||
@@ -114,6 +116,7 @@ export default function Home() {
     layerVisibility.combustionPlants,
     layerVisibility.districtEnergySystems,
     layerVisibility.foodProcessors,
+    layerVisibility.tomatoProcessors,
     layerVisibility.foodRetailers,
     layerVisibility.powerPlants,
     layerVisibility.foodBanks,
@@ -198,6 +201,7 @@ export default function Home() {
       combustionPlants: isVisible,
       districtEnergySystems: isVisible,
       foodProcessors: isVisible,
+      tomatoProcessors: isVisible,
       foodRetailers: isVisible,
       powerPlants: isVisible,
       foodBanks: isVisible,

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -2569,7 +2569,6 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
           'saf-plants-layer': 'Sustainable Aviation Fuel Plant Details',
           'renewable-diesel-layer': 'Renewable Diesel Plant Details',
           'landfill-lfg-layer': 'Landfill LFG Project Details',
-          'landfill-lfg-layer': 'Landfill LFG Project Details',
           'wastewater-treatment-layer': 'Wastewater Treatment Plant Details',
           'waste-to-energy-layer': 'Waste to Energy Plant Details',
     'combustion-plants-layer': 'Combustion Plant Details',

--- a/src/lib/labelMappings.js
+++ b/src/lib/labelMappings.js
@@ -231,6 +231,88 @@ export const FARMERS_MARKETS_LABELS = {
   'lon': 'Longitude',
 };
 
+export const WASTE_TO_ENERGY_LABELS = {
+  'Plant_Name': 'Plant Name',
+  'City': 'City',
+  'County': 'County',
+  'State': 'State',
+  'Technology': 'Technology',
+  'Total_MW': 'Total Capacity (MW)',
+  'Primary_Purpose': 'Primary Purpose',
+  'Status': 'Status',
+  'lat': 'Latitude',
+  'lon': 'Longitude',
+};
+
+export const COMBUSTION_PLANTS_LABELS = {
+  'Plant_Name': 'Plant Name',
+  'City': 'City',
+  'County': 'County',
+  'State': 'State',
+  'Technology': 'Technology',
+  'Energy_Source': 'Energy Source',
+  'Total_MW': 'Total Capacity (MW)',
+  'Status': 'Status',
+  'lat': 'Latitude',
+  'lon': 'Longitude',
+};
+
+export const DISTRICT_ENERGY_SYSTEMS_LABELS = {
+  'NAME': 'System Name',
+  'CITY': 'City',
+  'STATE': 'State',
+  'DES_TYPE': 'System Type',
+  'CAPACITY': 'Capacity',
+  'SERVICE_AREA': 'Service Area',
+  'lat': 'Latitude',
+  'lon': 'Longitude',
+};
+
+export const FREIGHT_TERMINALS_LABELS = {
+  'TERM_NAME': 'Terminal Name',
+  'MODE_TYPE': 'Mode Type',
+  'TERM_TYPE': 'Terminal Type',
+  'CITY': 'City',
+  'STATE_CD': 'State',
+  'COUNTY_NM': 'County',
+  'lat': 'Latitude',
+  'lon': 'Longitude',
+};
+
+export const FREIGHT_ROUTES_LABELS = {
+  'MODE': 'Mode',
+  'MILES': 'Miles',
+  'STATE': 'State',
+  'ROUTE_TYPE': 'Route Type',
+};
+
+export const PETROLEUM_PIPELINES_LABELS = {
+  'OPERATOR': 'Operator',
+  'TYPEPIPE': 'Pipe Type',
+  'DIAMETER': 'Diameter',
+  'CAPACITY': 'Capacity',
+  'STATUS': 'Status',
+  'STATE': 'State',
+};
+
+export const CRUDE_OIL_PIPELINES_LABELS = {
+  'OPERATOR': 'Operator',
+  'TYPEPIPE': 'Pipe Type',
+  'DIAMETER': 'Diameter',
+  'CAPACITY': 'Capacity',
+  'STATUS': 'Status',
+  'STATE': 'State',
+};
+
+export const NATURAL_GAS_PIPELINES_LABELS = {
+  'PIPELNNAME': 'Pipeline Name',
+  'OPERATOR': 'Operator',
+  'TYPEPIPE': 'Pipe Type',
+  'DIAMETER': 'Diameter',
+  'STATUS': 'Status',
+  'STATE': 'State',
+};
+
 export const layerLabelMappings = {
   'renewable-diesel': RENEWABLE_DIESEL_PLANTS_LABELS,
   'saf-plants': SUSTAINABLE_AVIATION_FUEL_PLANTS_LABELS,
@@ -247,4 +329,12 @@ export const layerLabelMappings = {
   'power-plants': POWER_PLANTS_LABELS,
   'food-banks': FOOD_BANKS_LABELS,
   'farmers-markets': FARMERS_MARKETS_LABELS,
+  'waste-to-energy': WASTE_TO_ENERGY_LABELS,
+  'combustion-plants': COMBUSTION_PLANTS_LABELS,
+  'district-energy-systems': DISTRICT_ENERGY_SYSTEMS_LABELS,
+  'freight-terminals': FREIGHT_TERMINALS_LABELS,
+  'freight-routes': FREIGHT_ROUTES_LABELS,
+  'petroleum-pipelines': PETROLEUM_PIPELINES_LABELS,
+  'crude-oil-pipelines': CRUDE_OIL_PIPELINES_LABELS,
+  'natural-gas-pipelines': NATURAL_GAS_PIPELINES_LABELS,
 };

--- a/tests/label-mappings.test.ts
+++ b/tests/label-mappings.test.ts
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { layerLabelMappings } from '../src/lib/labelMappings.js';
+
+// Every layer listed in Map.js interactiveLayers must have an entry here so
+// popups (callout boxes) show human-readable labels instead of raw field names.
+const EXPECTED_LAYER_KEYS = [
+  'renewable-diesel',
+  'saf-plants',
+  'cement-plants',
+  'mrf',
+  'rail-lines',
+  'anaerobic-digester',
+  'biorefineries',
+  'biodiesel-plants',
+  'landfill-lfg',
+  'wastewater-treatment',
+  'food-processors',
+  'food-retailers',
+  'power-plants',
+  'food-banks',
+  'farmers-markets',
+  // These were missing — their popups showed raw field names:
+  'waste-to-energy',
+  'combustion-plants',
+  'district-energy-systems',
+  'freight-terminals',
+  'freight-routes',
+  'petroleum-pipelines',
+  'crude-oil-pipelines',
+  'natural-gas-pipelines',
+];
+
+for (const layerKey of EXPECTED_LAYER_KEYS) {
+  test(`layerLabelMappings has an entry for '${layerKey}'`, () => {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(layerLabelMappings, layerKey),
+      `Missing label mapping for layer '${layerKey}' — its popup will show raw field names`
+    );
+  });
+}


### PR DESCRIPTION
closes #47

## Summary

- **Missing popup label mappings:** 8 infrastructure/transportation layers (waste-to-energy, combustion-plants, district-energy-systems, freight-terminals, freight-routes, petroleum-pipelines, crude-oil-pipelines, natural-gas-pipelines) were registered in `interactiveLayers` but had no entry in `labelMappings.js`. Clicking those facilities showed raw field names in the callout box. Added label dictionaries for all 8 using standard EIA/HIFLD/FTOT field names.
- **tomatoProcessors layer silently reset:** `tomatoProcessors` was absent from the `layerVisibility` state in `page.tsx`. Map.js's `useEffect` watches `layerVisibility` and, finding `layerVisibility.tomatoProcessors === undefined` (falsy), set the layer to `'none'` every time any other layer was toggled, making its callout popup unreachable. Fixed by adding `tomatoProcessors: false` to the initial state and wiring it into `computedInfrastructureMaster` and `handleInfrastructureToggle`.
- **Duplicate landfill entry:** Removed duplicate `'landfill-lfg-layer'` key in `interactiveLayers` in Map.js.

## Test plan

- [ ] Open the map and enable Infrastructure layers
- [ ] Click a Waste-to-Energy, Combustion Plant, or District Energy System point — verify the callout box shows human-readable field labels instead of raw names
- [ ] Enable Tomato Processors (under Food Processors), then toggle any unrelated layer on/off — verify Tomato Processors remains visible and its callout boxes still appear
- [ ] Verify no regression on layers that already had label mappings (Anaerobic Digesters, Biodiesel Plants, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
