### PR TITLE
ci: enforce staging-first merge policy

### DIFF
--- a/.github/workflows/enforce-staging-gate.yml
+++ b/.github/workflows/enforce-staging-gate.yml
@@ -1,0 +1,24 @@
+name: Enforce staging-first merge policy
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-source-branch:
+    name: Source branch must be staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject PRs not based on staging
+        if: github.head_ref != 'staging'
+        run: |
+          echo "PRs to main must come from the staging branch."
+          echo "Current source branch: ${{ github.head_ref }}"
+          echo ""
+          echo "Correct workflow: feature branch -> staging -> main"
+          echo "Please merge your changes to staging first, then open a PR from staging to main."
+          exit 1
+
+      - name: Approved
+        run: echo "Source branch is staging -- PR to main is allowed."


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/enforce-staging-gate.yml`, a GitHub Actions check that blocks any PR to `main` whose source branch is not `staging`
- Enforces the intended `feature branch → staging → main` workflow going forward
- Addresses the root cause identified in the investigation: patches were previously applied directly to `main`, causing main and staging to diverge with different commit hashes for the same changes

## Context

Two PRs (#33, #44) bypassed staging by merging directly from feature branches to main, producing 4 divergent commits with identical messages but different hashes. This workflow makes that pattern fail CI so it cannot happen again.

## What it does

- Triggers on every PR targeting `main`
- If the source branch is anything other than `staging`, the check fails with a clear message pointing to the correct workflow
- If the source branch is `staging`, the check passes

## Remaining items (require human action)

- **Cloud Build trigger**: Check GCP Cloud Build Triggers for a scheduled or manual trigger running on `main` (explains Jun 3 builds with no new commits)
- **History reconciliation**: Decide between force-pushing main to staging HEAD or a merge PR from `staging` to `main` to resolve the 4 divergent commits

## Test plan

- [ ] Open a test PR from a feature branch to `main` — confirm the check fails
- [ ] Confirm a PR from `staging` to `main` passes the check
- [ ] Optionally add this as a required status check in GitHub branch protection settings for `main`

Generated with [Claude Code](https://claude.ai/claude-code)
