### PR TITLE
fix(cloudbuild): add lightningcss-linux-x64-gnu to optionalDeps so lockfile includes Linux binary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1339,6 +1339,17 @@ Mapbox tokens are passed as `--build-arg` at build time (baked into the client b
 
 ### Google Cloud Run
 
+**GCP Project ID:** `biocirv-470318`
+
+All `gcloud` commands must include `--project=biocirv-470318` explicitly. Never rely on the ambient `gcloud config get-value project` — it may point to a different project (e.g. `pisces-476117`) in a shared shell environment.
+
+```bash
+# Always use --project, e.g.:
+gcloud builds list --region=us-west1 --project=biocirv-470318 ...
+gcloud builds describe <BUILD_ID> --region=us-west1 --project=biocirv-470318
+gcloud run deploy ... --project=biocirv-470318
+```
+
 Three Cloud Build pipelines deploy to Cloud Run:
 
 | Config file | Cloud Run service | Backend API |

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,9 @@
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
         "typescript": "^5"
+      },
+      "optionalDependencies": {
+        "lightningcss-linux-x64-gnu": "1.30.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -7530,6 +7533,26 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 12.0.0"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "swr": "^2.3.3",
     "tailwind-merge": "^3.2.0"
   },
+  "optionalDependencies": {
+    "lightningcss-linux-x64-gnu": "1.30.2"
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary

- `package-lock.json` was regenerated on macOS ARM64 (commit `a63037a`) and omitted `lightningcss-linux-x64-gnu` — the Linux x64 native binary package that Turbopack needs for CSS processing via `@tailwindcss/postcss`
- Added `lightningcss-linux-x64-gnu@1.30.2` to project `optionalDependencies` so npm records it in the lockfile on any host platform; on Linux CI it's now found and installed
- Also adds `biocirv-470318` GCP project ID guidance to `AGENTS.md` with a rule that all `gcloud` commands must pass `--project=biocirv-470318` explicitly

## Test plan

- [ ] Trigger a Cloud Build on `staging` after this merges — confirm `docker build` step (Step 0) passes and the image is pushed
- [ ] Confirm `npm run build` succeeds locally inside a Linux container (`docker run --rm -v $(pwd):/app -w /app node:20.20.0-slim npm install && npm run build`)
- [ ] Verify `node_modules/lightningcss-linux-x64-gnu/` is present after `npm install` on Linux
- [ ] Confirm no regressions in the deployed staging app

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)
