### PR TITLE
fix(cloudbuild): add @tailwindcss/oxide-linux-x64-gnu to optionalDeps so lockfile includes Linux binary (closes #59)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "typescript": "^5"
       },
       "optionalDependencies": {
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
         "lightningcss-linux-x64-gnu": "1.30.2"
       }
     },
@@ -1944,6 +1945,22 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
+      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 10"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "tailwind-merge": "^3.2.0"
   },
   "optionalDependencies": {
-    "lightningcss-linux-x64-gnu": "1.30.2"
+    "lightningcss-linux-x64-gnu": "1.30.2",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.1.18"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary

- Adds `@tailwindcss/oxide-linux-x64-gnu@4.1.18` to `optionalDependencies` in `package.json`
- Regenerates `package-lock.json` to include the Linux x64 native binary entry
- Fixes Cloud Build failures that began after commit `a63037a` regenerated the lockfile on macOS ARM64

## Root Cause

`a63037a` regenerated `package-lock.json` on macOS ARM64, which recorded only the darwin-arm64 binary for `@tailwindcss/oxide`. The Linux binary (`@tailwindcss/oxide-linux-x64-gnu`) was absent, so `npm install` inside the Linux Docker container skipped it. At build time, Turbopack's CSS pipeline called `@tailwindcss/oxide/index.js`, which couldn't load its native binding and threw "Cannot find native binding."

This is the same root cause as #57 / `ae47ac2` (which fixed `lightningcss-linux-x64-gnu`). That fix only addressed lightningcss; this PR addresses the oxide binary with the same pattern.

## Test plan

- [ ] Cloud Build on `staging` passes `docker build` step (previously failing at `npm run build`)
- [ ] `@tailwindcss/oxide-linux-x64-gnu` entry is present in `package-lock.json` (`grep '"node_modules/@tailwindcss/oxide-linux-x64-gnu"' package-lock.json`)
- [ ] No regression in other steps (push, deploy, traffic update)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
