### PR TITLE
feat: integrate LandIQ 2024 cropland tileset

### DIFF
--- a/docs/LANDIQ_2024_INTEGRATION_PLAN.md
+++ b/docs/LANDIQ_2024_INTEGRATION_PLAN.md
@@ -166,9 +166,9 @@ Goal: when a polygon carries `resources: string[]`, use those API resource names
 
 | Placeholder | Title | Issue # |
 |---|---|---|
-| S1 | Write streaming GeoJSON preprocessing script | #?S1 |
-| S2 | Update frontend tileset registry for 2024 data | #?S2 |
-| S3 | Update tileset specification docs | #?S3 |
-| S4 | Cut tippecanoe tileset and upload to Mapbox | #?S4 |
-| S5 | End-to-end verification and staging deploy | #?S5 |
-| S6 | Workstream 2: four-tier residue wiring | #?S6 |
+| S1 | Write streaming GeoJSON preprocessing script | #77 |
+| S2 | Update frontend tileset registry for 2024 data | #71 |
+| S3 | Update tileset specification docs | #72 |
+| S4 | Cut tippecanoe tileset and upload to Mapbox | #73 |
+| S5 | End-to-end verification and staging deploy | #74 |
+| S6 | Workstream 2: four-tier residue wiring | #75 |

--- a/docs/LANDIQ_2024_INTEGRATION_PLAN.md
+++ b/docs/LANDIQ_2024_INTEGRATION_PLAN.md
@@ -1,0 +1,174 @@
+# Plan: Integrate updated LandIQ 2024 cropland data
+
+## Context
+
+Peter (collaborator) produced an updated **LandIQ 2024** California cropland dataset and gave us two options:
+1. A **cleaned GeoJSON** (`landiq_tileset_20260609_122659.geojson`, 625 MB, 456,223 polygons) -- already flattened to `main_crop`, `acres`, `county`, `geoid`, `tileset_id`, and a new `resources` array (residue feedstocks mapped to the crop).
+2. The **full provisional LandIQ 2024 shapefile** (raw, all attributes, likely projected CRS).
+
+The app's cropland layer is a **Mapbox vector tileset** (`tylerhuntington222.cropland_landiq_2023`, source layer `cropland_land_iq_2023`) referenced from the frontend registry. We need to swap in the 2024 data with minimal disruption to the existing wiring.
+
+### Recommendation: use Peter's GeoJSON (do NOT chase the shapefile)
+
+- tippecanoe (the standard Mapbox tile-cutting tool; `tippecanoe`/`ogr2ogr`/`tile-join` are installed locally) ingests GeoJSON **directly**; a shapefile must first be `ogr2ogr`-converted anyway.
+- Peter already did the flatten/join we need (polygon + the 4 columns the app reads), and the GeoJSON is already in WGS84/CRS84 (web-ready). The shapefile is raw and likely EPSG:3310, needing reprojection + re-flattening.
+- **Decisive finding:** the new data uses the *identical crop taxonomy* the frontend already hardcodes -- just lowercased. Every one of the 56 real crop classes maps 1:1 to an existing canonical `main_crop_name`. So the frontend's color map, crop-name->residue mapping, and resource mapping all keep working with **no vocabulary changes**.
+
+### Why this is fundamentally a value-normalization job
+
+The frontend's canonical crop vocabulary lives in three mutually-consistent places:
+- `src/components/LayerControls.tsx:100-118` -- `cropColorMapping` (56 keys; drives the checkbox UI via `allCropNames`)
+- `src/components/Map.js:1253-1308` -- `fill-color` `match` on `main_crop_name` (same 56 keys)
+- `src/lib/constants.ts:13-95` -- `CROP_NAME_MAPPING` keys (Title-Case LandIQ names -> residue lookup)
+
+Peter's GeoJSON `main_crop` values are the same names, lowercased (`"almonds"`, `"corn, sorghum and sudan"`, `"idle - long term"`, ...). Mapping lowercase->canonical is deterministic.
+
+### Schema gaps between Peter's GeoJSON and what the frontend reads
+
+| Frontend reads | New GeoJSON has | Reconciliation |
+|---|---|---|
+| `main_crop_name` (Title Case, e.g. "Almonds") | `main_crop` (lowercase, e.g. "almonds") | Rename + normalize value to canonical during preprocessing |
+| `main_crop_code` (filter `!= 'U'` hides urban) | *(absent)* | Synthesize: `'U'` for `{"u","ul2"}`, `''` otherwise |
+| `county` (case-insensitive lookup) | `county` (lowercase, incl. `"****"` masked) | Keep as-is |
+| `acres` | `acres` | Keep as-is |
+| `region`, `hydro_region` (popup only) | *(absent)* | Optional; popups simply omit them (graceful) |
+| (derives geoid client-side from county) | `geoid` (100% null) | Drop -- unused |
+| (computes residues client-side) | `resources` (~40% populated) | Encode as pipe-delimited string |
+
+**Value-normalization mechanism:** build the lookup as `{ canonical.toLowerCase(): canonical }` over the 56 `cropColorMapping` keys. Run the script in **UTF-8** (Python3 default) and compare exact strings.
+
+Explicit overrides:
+- `"citrus"` -> `"Citrus and Subtropical"`
+- `"u"`/`"ul2"` -> urban: set `main_crop_code='U'`, `main_crop_name='Unclassified'`
+
+**Assert 100% coverage** against the 58 distinct values (56 crops + `u` + `ul2`); abort on any unmapped non-urban value.
+
+## Confirmed decisions
+
+1. **Upload target:** `sustainasoft` account -> `sustainasoft.cal-bioscape-landiq-cropland-2026-06`, `accountType: 'default'`. User provides a sustainasoft secret write-token.
+2. **`resources` array is a new PRIMARY tier.** When a polygon carries `resources`, query the API per-resource for residue quantities first, fall back to the existing three-tier chain.
+
+## Workstream 1: Rebuild and swap the tileset (ships independently)
+
+### Phase A: Preprocess the GeoJSON (local)
+
+Write a streaming Python script (`scripts/preprocess_landiq.py`) that reads the 625 MB / 456k feature GeoJSON via streaming (must not load whole file) and emits newline-delimited GeoJSONSeq. Per feature:
+
+- `main_crop_name` = canonical name from the lowercase->canonical lookup
+- `main_crop_code` = `'U'` for `{u, ul2}`, else `''`
+- `acres`, `county` (passthrough; `county='****'` is acceptable)
+- `resources` = pipe-delimited string (`"almond hulls|almond shells|almond branches"`); omit property entirely if null
+
+Assert 100% coverage; fail loud / abort on any unmapped non-urban value.
+
+### Phase B: Cut the tileset (local, tippecanoe)
+
+Source layer name (stable): **`cropland_land_iq`** (drops the `_2023` suffix).
+
+```
+tippecanoe -o landiq_2024.mbtiles -l cropland_land_iq \
+  -Z6 -z14 \
+  --drop-densest-as-needed \
+  --coalesce-smallest-as-needed \
+  --extend-zooms-if-still-dropping \
+  --no-tile-size-limit
+```
+
+Verify with `tippecanoe-decode`/Mapbox Studio: source layer `cropland_land_iq`, all four properties present, urban polygons carry code `U`.
+
+### Phase C: Upload to Mapbox (blocked: sustainasoft write-token from user)
+
+- Account: `sustainasoft`
+- Tileset ID: `sustainasoft.cal-bioscape-landiq-cropland-2026-06`
+- Upload method: Mapbox Uploads API via curl, or `pip install mapbox-tilesets`
+- No env changes needed: Cloud Build already injects `mapbox-access-token` from Secret Manager
+
+### Phase D: Frontend wiring (one file edit)
+
+In `src/lib/tileset-registry.ts`, update the `feedstock` entry:
+
+- `tilesetId` -> `sustainasoft.cal-bioscape-landiq-cropland-2026-06`
+- `sourceLayer` -> `cropland_land_iq`
+- `version` -> `2026-06`
+- `accountType` -> `default`
+
+No changes to Map.js color match, LayerControls, constants, resource-mapping, or county-lookup.
+
+### Phase E: Documentation
+
+Update `docs/TILESET_SPECIFICATIONS.md` and `docs/TILESET_UPDATE_GUIDE.md`:
+- New tileset ID and version
+- Preprocessing mapping notes (source field names, normalization mechanism)
+- Commit the preprocessing script pointer under `scripts/`
+
+## Workstream 2: Four-tier residue wiring (blocked: Peter's API answers)
+
+Goal: when a polygon carries `resources: string[]`, use those API resource names as the **primary** source for residue quantities/availability/composition; keep the current chain as fallback.
+
+### Mechanics
+
+- Vector tiles deliver `resources` as a pipe-delimited string -> add helper `parseFeatureResources(props)` returning `string[]` via `props.resources?.split('|') ?? []`
+- New helper `getResidueFactorsByResourceNames(resourceNames, acres)` in `src/lib/resource-mapping.ts`: maps each API resource name -> residue factors/quantity, bypassing the `main_crop_name -> getApiResource` guess
+- Carry `resources?: string[]` on the `CropInventory` type
+
+### Four insertion points (all "resources-first, else existing")
+
+1. `Map.js` popup ~2374-2438: residue calc + `apiResource` lookup
+2. `Map.js` buffer analysis ~484-617: collect `resources` per intersecting feature
+3. `SitingInventory.tsx` ~162-187 (`baseResidueRows`): residue rows from `crop.resources` first
+4. `SitingInventory.tsx` ~107-157: availability + composition fetch loops key off `crop.resources` first
+
+### Fallback order (four-tier system)
+
+1. Per-polygon `resources` -> API per-resource -> quantity/availability/composition
+2. `getApiResource(main_crop_name)` -> API
+3. `getCropResidueFactors` dynamic JSON
+4. Literature `RESIDUE_FALLBACKS`
+
+### Open questions for Peter (gate quantity wiring)
+
+- Which endpoint returns residue **tonnage** for a `{resource, geoid}`?
+- Are all values in the `resources` arrays live, queryable API resource names?
+- For multiple residues per crop in a buffer, sum across all or designate a primary?
+
+## Blocking inputs from user
+
+- **sustainasoft secret write-token** (Phase C only): gates tileset upload, not code changes
+- **Peter's answers** to API questions: gates Workstream 2 quantity wiring only
+
+## Verification checklist
+
+1. Preprocess script reports 0 unmapped non-urban crop values across all 456k features; spot-check 5 crops (almonds, citrus, corn, sugar beets, one idle class).
+2. `tippecanoe-decode`/Mapbox Studio confirms: source layer `cropland_land_iq`; `main_crop_name`/`main_crop_code`/`acres`/`county` present; urban polygons carry code `U`.
+3. Local app (`npm run dev`) with registry pointing at new tileset:
+   - Map renders crop polygons in correct colors; urban land hidden
+   - Crop checkboxes (LayerControls) filter correctly
+   - Click a polygon -> popup shows crop/acres/county + residue yields
+   - Buffer/siting analysis tallies acreage by crop
+   - No console errors; no "source layer not found"
+4. Staging deploy succeeds and Cloud Build reports SUCCESS.
+
+## Critical files
+
+- `src/lib/tileset-registry.ts` -- the only required code edit (feedstock entry)
+- `scripts/preprocess_landiq.py` -- new; reads canonical vocab to build the lookup
+- Reference (unchanged, used to build the lookup): `src/components/LayerControls.tsx:100-118`, `src/components/Map.js:1253-1308`, `src/lib/constants.ts:13-95`
+- `docs/TILESET_SPECIFICATIONS.md`, `docs/TILESET_UPDATE_GUIDE.md`
+
+## Workstream 2 critical files
+
+- `src/lib/resource-mapping.ts` -- new `getResidueFactorsByResourceNames`; add `parseFeatureResources` helper
+- `src/components/Map.js` -- popup + buffer insertion points
+- `src/components/SitingInventory.tsx` -- residue rows + availability/composition fetch loops; extend `CropInventory` type with `resources?: string[]`
+- `src/lib/api.ts` -- possibly a new per-resource quantity call, pending Peter's endpoint answer
+
+## Sub-issue map (backfilled after creation)
+
+| Placeholder | Title | Issue # |
+|---|---|---|
+| S1 | Write streaming GeoJSON preprocessing script | #?S1 |
+| S2 | Update frontend tileset registry for 2024 data | #?S2 |
+| S3 | Update tileset specification docs | #?S3 |
+| S4 | Cut tippecanoe tileset and upload to Mapbox | #?S4 |
+| S5 | End-to-end verification and staging deploy | #?S5 |
+| S6 | Workstream 2: four-tier residue wiring | #?S6 |

--- a/docs/LANDIQ_2024_INTEGRATION_PLAN.md
+++ b/docs/LANDIQ_2024_INTEGRATION_PLAN.md
@@ -45,7 +45,7 @@ Explicit overrides:
 
 ## Confirmed decisions
 
-1. **Upload target:** `sustainasoft` account -> `sustainasoft.cal-bioscape-landiq-cropland-2026-06`, `accountType: 'default'`. User provides a sustainasoft secret write-token.
+1. **Upload target:** `sustainasoft` account -> `sustainasoft.landiq-cropland-2026-06`, `accountType: 'default'`. User provides a sustainasoft secret write-token.
 2. **`resources` array is a new PRIMARY tier.** When a polygon carries `resources`, query the API per-resource for residue quantities first, fall back to the existing three-tier chain.
 
 ## Workstream 1: Rebuild and swap the tileset (ships independently)
@@ -79,7 +79,7 @@ Verify with `tippecanoe-decode`/Mapbox Studio: source layer `cropland_land_iq`, 
 ### Phase C: Upload to Mapbox (blocked: sustainasoft write-token from user)
 
 - Account: `sustainasoft`
-- Tileset ID: `sustainasoft.cal-bioscape-landiq-cropland-2026-06`
+- Tileset ID: `sustainasoft.landiq-cropland-2026-06`
 - Upload method: Mapbox Uploads API via curl, or `pip install mapbox-tilesets`
 - No env changes needed: Cloud Build already injects `mapbox-access-token` from Secret Manager
 
@@ -87,7 +87,7 @@ Verify with `tippecanoe-decode`/Mapbox Studio: source layer `cropland_land_iq`, 
 
 In `src/lib/tileset-registry.ts`, update the `feedstock` entry:
 
-- `tilesetId` -> `sustainasoft.cal-bioscape-landiq-cropland-2026-06`
+- `tilesetId` -> `sustainasoft.landiq-cropland-2026-06`
 - `sourceLayer` -> `cropland_land_iq`
 - `version` -> `2026-06`
 - `accountType` -> `default`

--- a/docs/TILESET_SPECIFICATIONS.md
+++ b/docs/TILESET_SPECIFICATIONS.md
@@ -75,7 +75,7 @@ This allows different environments (dev, staging, prod) to use different tileset
 This tileset contains agricultural cropland data from LandIQ's 2024 Crop Mapping Dataset for California.
 
 ### Tileset Details
-- **Tileset ID**: `sustainasoft.cal-bioscape-landiq-cropland-2026-06`
+- **Tileset ID**: `sustainasoft.landiq-cropland-2026-06`
 - **Source Layer Name**: `cropland_land_iq` (stable across versions)
 - **Geometry Type**: Polygon/MultiPolygon
 - **Data Source**: LandIQ 2024 provisional data (Peter's cleaned GeoJSON `landiq_tileset_20260609_122659.geojson`)
@@ -1046,7 +1046,7 @@ When updating tilesets, also update:
 - Goal: Keep tile sizes <500kb for fast rendering; ensure data freshness for transactional attributes
 
 ### Version 2.1 (2026-06-17)
-- **Feedstock tileset updated to LandIQ 2024 data**: new ID `sustainasoft.cal-bioscape-landiq-cropland-2026-06`
+- **Feedstock tileset updated to LandIQ 2024 data**: new ID `sustainasoft.landiq-cropland-2026-06`
 - Source layer name unchanged: `cropland_land_iq`
 - Schema updated: `feedstock_id`, `residue_type`, `total_yield` removed (not in 2024 source); `main_crop_code` added (synthesized urban filter); `resources` added (pipe-delimited residue feedstock names, ~40% populated)
 - Preprocessing: `scripts/preprocess_landiq.py` normalizes lowercase `main_crop` -> canonical Title-Case `main_crop_name`; encodes `resources` JSON array as pipe-delimited string; asserts 100% crop coverage (exits non-zero on unmapped values)

--- a/docs/TILESET_SPECIFICATIONS.md
+++ b/docs/TILESET_SPECIFICATIONS.md
@@ -72,15 +72,15 @@ This allows different environments (dev, staging, prod) to use different tileset
 ## Feedstock/Crop Residues Tileset
 
 ### Overview
-This tileset contains agricultural cropland data from LandIQ's 2023 Crop Mapping Dataset for California.
+This tileset contains agricultural cropland data from LandIQ's 2024 Crop Mapping Dataset for California.
 
 ### Tileset Details
-- **Tileset ID**: `sustainasoft.cal-bioscape-landiq-cropland-2024-10`
+- **Tileset ID**: `sustainasoft.cal-bioscape-landiq-cropland-2026-06`
 - **Source Layer Name**: `cropland_land_iq` (stable across versions)
 - **Geometry Type**: Polygon/MultiPolygon
-- **Data Source**: LandIQ 2023 Crop Mapping Dataset
+- **Data Source**: LandIQ 2024 provisional data (Peter's cleaned GeoJSON `landiq_tileset_20260609_122659.geojson`)
 - **URL**: https://www.landiq.com/data/
-- **Version**: 2024-10
+- **Version**: 2026-06
 
 **Note**: The tileset ID includes a date-based version identifier (YYYY-MM). When this tileset is regenerated with updated data, only the version identifier changes. The source layer name remains stable to minimize code changes.
 
@@ -104,14 +104,13 @@ The feedstock data is partitioned into three accessibility tiers to optimize per
 
 | Field Name | Data Type | Description | Required | Example |
 |------------|-----------|-------------|----------|---------|
-| `feedstock_id` | String (UUID) | Unique identifier for the feedstock polygon. **Critical join key** for API lookups and static data joins. | Yes | "550e8400-e29b-41d4-a716-446655440000" |
-| `residue_type` | String | Type of crop residue. **Must match keys in `feedstock_definitions.json` exactly.** | Yes | "Prunings", "Stover", "Straw & Stubble" |
-| `total_yield` | Float | Total yield (dry tons) for quantitative scaling/opacity | Yes | 225.75 |
-| `main_crop_name` | String | Full name of the crop type (for display) | Yes | "Almonds", "Grapes", "Corn" |
-| `acres` | Float | Area of the field in acres | Yes | 145.67 |
-| `county` | String | County name where field is located | Yes | "Fresno" |
+| `main_crop_name` | String | Canonical Title-Case crop name (56 classes from cropColorMapping). Synthesized from source `main_crop` (lowercase) during preprocessing. | Yes | `"Almonds"`, `"Citrus and Subtropical"`, `"Unclassified"` |
+| `main_crop_code` | String | Urban filter code. `'U'` for urban parcels (source values `u`/`ul2`), empty string otherwise. Used to hide urban land from the map. | Yes | `""` or `"U"` |
+| `acres` | Float | Area of the parcel in acres. | Yes | `145.67` |
+| `county` | String | County name (lowercase passthrough from source). `"****"` for masked parcels -- frontend handles gracefully. | Yes | `"fresno"` |
+| `resources` | String | Pipe-delimited list of API resource names for residue feedstocks mapped to this crop (e.g. `"almond hulls\|almond shells"`). **Absent** when the source polygon has no resource mapping (~60% of features). Client reads via `.split('\|')`. | No | `"almond hulls\|almond shells\|almond branches"` |
 
-**Note**: The `residue_type` string in tiles MUST strictly match the keys in the static JSON lookup. A shared Enum definition should be used to ensure consistency.
+**Preprocessing note**: Peter's source GeoJSON uses `main_crop` (lowercase) with no `main_crop_code`. The script `scripts/preprocess_landiq.py` normalizes these to the canonical frontend vocabulary and encodes the `resources` array as a pipe-delimited string. Fields `geoid` (100% null), `tileset_id`, and the raw `main_crop` are dropped.
 
 ---
 
@@ -1045,6 +1044,14 @@ When updating tilesets, also update:
 - Defined shared `ResidueType` Enum for data consistency between tiles and static JSON
 - Specified API endpoint patterns using Query Parameters (`GET /api/feedstocks?id={feedstock_uuid}`)
 - Goal: Keep tile sizes <500kb for fast rendering; ensure data freshness for transactional attributes
+
+### Version 2.1 (2026-06-17)
+- **Feedstock tileset updated to LandIQ 2024 data**: new ID `sustainasoft.cal-bioscape-landiq-cropland-2026-06`
+- Source layer name unchanged: `cropland_land_iq`
+- Schema updated: `feedstock_id`, `residue_type`, `total_yield` removed (not in 2024 source); `main_crop_code` added (synthesized urban filter); `resources` added (pipe-delimited residue feedstock names, ~40% populated)
+- Preprocessing: `scripts/preprocess_landiq.py` normalizes lowercase `main_crop` -> canonical Title-Case `main_crop_name`; encodes `resources` JSON array as pipe-delimited string; asserts 100% crop coverage (exits non-zero on unmapped values)
+- `accountType` changed from `legacy` to `default` (sustainasoft public token now used via Cloud Build Secret Manager)
+- `region` and `hydro_region` not present in 2024 source; popup rows omitted gracefully
 
 ### Version 1.2 (2025-10-16)
 - **MAJOR UPDATE**: Implemented standardized tileset naming convention with versioning

--- a/docs/TILESET_UPDATE_GUIDE.md
+++ b/docs/TILESET_UPDATE_GUIDE.md
@@ -485,4 +485,13 @@ For questions or issues with tileset updates:
 
 ## Version History
 
+- **v2.0 (2026-06-17)**: Feedstock tileset updated to LandIQ 2024 data
+  - **New tileset ID**: `sustainasoft.cal-bioscape-landiq-cropland-2026-06`
+  - **Source**: LandIQ 2024 provisional data, Peter's cleaned GeoJSON (`landiq_tileset_20260609_122659.geojson`, 625 MB, 456,223 polygons)
+  - **Source layer**: `cropland_land_iq` (unchanged)
+  - **Preprocessing**: `scripts/preprocess_landiq.py` -- streaming normalization (no full-file load); lowercase `main_crop` -> canonical Title-Case `main_crop_name`; synthesizes `main_crop_code='U'` for urban values `u`/`ul2`; encodes `resources` JSON array as pipe-delimited string; aborts on any unmapped non-urban crop value
+  - **tippecanoe flags**: `-Z6 -z14 --drop-densest-as-needed --coalesce-smallest-as-needed --extend-zooms-if-still-dropping --no-tile-size-limit`
+  - **Mapbox account**: `sustainasoft` (accountType changed from `legacy` to `default`; public token via Cloud Build Secret Manager `mapbox-access-token`)
+  - **GitHub epic**: #70
+
 - **v1.0 (2024-10-16)**: Initial guide for simplified tileset management system

--- a/docs/TILESET_UPDATE_GUIDE.md
+++ b/docs/TILESET_UPDATE_GUIDE.md
@@ -486,7 +486,7 @@ For questions or issues with tileset updates:
 ## Version History
 
 - **v2.0 (2026-06-17)**: Feedstock tileset updated to LandIQ 2024 data
-  - **New tileset ID**: `sustainasoft.cal-bioscape-landiq-cropland-2026-06`
+  - **New tileset ID**: `sustainasoft.landiq-cropland-2026-06`
   - **Source**: LandIQ 2024 provisional data, Peter's cleaned GeoJSON (`landiq_tileset_20260609_122659.geojson`, 625 MB, 456,223 polygons)
   - **Source layer**: `cropland_land_iq` (unchanged)
   - **Preprocessing**: `scripts/preprocess_landiq.py` -- streaming normalization (no full-file load); lowercase `main_crop` -> canonical Title-Case `main_crop_name`; synthesizes `main_crop_code='U'` for urban values `u`/`ul2`; encodes `resources` JSON array as pipe-delimited string; aborts on any unmapped non-urban crop value

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node --require ./node_modules/tsx/dist/cjs/index.cjs --test 'tests/*.test.ts'",
     "test:e2e": "playwright test",
     "fetch-data": "tsx scripts/fetch-tomato-processor-facilities.ts",
     "merge-data": "tsx scripts/data-manipulation.ts",
     "audit": "npm audit --audit-level=high",
     "test": "tsx --test tests/*.test.ts",
     "build-carb-data": "tsx scripts/build-carb-food-processors.ts",
-    "upload-carb-tileset": "tsx scripts/upload-carb-tileset.ts"
+    "upload-carb-tileset": "tsx scripts/upload-carb-tileset.ts",
+    "upload-landiq-tileset": "tsx scripts/upload-landiq-tileset.ts"
   },
   "dependencies": {
     "@octokit/rest": "^22.0.1",

--- a/scripts/preprocess_landiq.py
+++ b/scripts/preprocess_landiq.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Preprocess LandIQ GeoJSON for Mapbox tileset ingestion.
+
+Converts Peter's cleaned LandIQ 2024 GeoJSON (main_crop lowercase, no main_crop_code)
+into a GeoJSONSeq file ready for tippecanoe. Streams the input -- never loads the
+full 625 MB file into memory.
+
+Usage:
+    python scripts/preprocess_landiq.py <input.geojson> <output.geojsons>
+    python scripts/preprocess_landiq.py --help
+
+Output format: one GeoJSON Feature per line (GeoJSONSeq / RFC 7946 Section 12).
+
+Dependencies: Python 3.8+ standard library only. For large files, ijson can be
+installed (pip install ijson) for lower peak RSS; the script detects it automatically.
+"""
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterator
+
+# ---------------------------------------------------------------------------
+# Canonical crop vocabulary (56 keys from cropColorMapping in LayerControls.tsx)
+# Hardcoded here so the script is self-contained; must stay in sync with that file.
+# ---------------------------------------------------------------------------
+CANONICAL_CROPS: list[str] = [
+    "Alfalfa & Alfalfa Mixtures",
+    "Almonds",
+    "Apples",
+    "Apricots",
+    "Avocados",
+    "Beans (Dry)",
+    "Bush Berries",
+    "Carrots",
+    "Cherries",
+    "Citrus and Subtropical",
+    "Cole Crops",
+    "Corn, Sorghum and Sudan",
+    "Cotton",
+    "Dates",
+    "Eucalyptus",
+    "Flowers, Nursery and Christmas Tree Farms",
+    "Grapes",
+    "Greenhouse",
+    "Idle – Long Term",
+    "Idle – Short Term",
+    "Induced high water table native pasture",
+    "Kiwis",
+    "Lettuce/Leafy Greens",
+    "Melons, Squash and Cucumbers",
+    "Miscellaneous Deciduous",
+    "Miscellaneous Field Crops",
+    "Miscellaneous Grain and Hay",
+    "Miscellaneous Grasses",
+    "Miscellaneous Subtropical Fruits",
+    "Miscellaneous Truck Crops",
+    "Mixed Pasture",
+    "Native Pasture",
+    "Olives",
+    "Onions and Garlic",
+    "Peaches/Nectarines",
+    "Pears",
+    "Pecans",
+    "Peppers",
+    "Pistachios",
+    "Plums",
+    "Pomegranates",
+    "Potatoes",
+    "Prunes",
+    "Rice",
+    "Safflower",
+    "Strawberries",
+    "Sugar beets",
+    "Sunflowers",
+    "Sweet Potatoes",
+    "Tomatoes",
+    "Turf Farms",
+    "Unclassified Fallow",
+    "Walnuts",
+    "Wheat",
+    "Wild Rice",
+    "Young Perennials",
+]
+
+# Build lowercase -> canonical lookup from the 56 canonical keys
+_LOOKUP: dict[str, str] = {c.lower(): c for c in CANONICAL_CROPS}
+
+# Explicit overrides: Peter's data uses "citrus" alone (not the full canonical name)
+_OVERRIDES: dict[str, str] = {
+    "citrus": "Citrus and Subtropical",
+}
+
+# Urban codes: these become main_crop_code='U', main_crop_name='Unclassified'
+_URBAN_CODES: set[str] = {"u", "ul2"}
+
+
+def normalize_feature(props: dict[str, Any]) -> dict[str, Any]:
+    """
+    Normalize a single feature's properties dict.
+
+    Returns a new dict with:
+      main_crop_name  -- canonical Title-Case crop name
+      main_crop_code  -- 'U' for urban, '' otherwise
+      acres           -- passthrough
+      county          -- passthrough (including '****')
+      resources       -- pipe-delimited string (omitted if null/empty)
+
+    Raises ValueError for any non-urban main_crop value that has no mapping.
+    """
+    raw = str(props.get("main_crop", "")).strip()
+
+    if raw in _URBAN_CODES:
+        out: dict[str, Any] = {
+            "main_crop_name": "Unclassified",
+            "main_crop_code": "U",
+            "acres": props.get("acres"),
+            "county": props.get("county"),
+        }
+    else:
+        canonical = _OVERRIDES.get(raw) or _LOOKUP.get(raw)
+        if canonical is None:
+            raise ValueError(f"Unmapped main_crop value: {raw!r}")
+        out = {
+            "main_crop_name": canonical,
+            "main_crop_code": "",
+            "acres": props.get("acres"),
+            "county": props.get("county"),
+        }
+
+    resources_raw = props.get("resources")
+    if isinstance(resources_raw, list) and resources_raw:
+        out["resources"] = "|".join(str(r) for r in resources_raw)
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Streaming readers
+# ---------------------------------------------------------------------------
+
+def _iter_features_ijson(path: Path) -> Iterator[dict]:
+    import ijson  # noqa: PLC0415
+    with path.open("rb") as fh:
+        yield from ijson.items(fh, "features.item")
+
+
+def _iter_features_stdlib(path: Path) -> Iterator[dict]:
+    """
+    Line-by-line fallback for when ijson is not installed. Works correctly when
+    the GeoJSON FeatureCollection has one feature per line (Peter's export format).
+    For files where the whole JSON is on one line, loads the full file (memory
+    cost is acceptable for files <1 GB on machines with >=4 GB RAM).
+    """
+    with path.open(encoding="utf-8") as fh:
+        content = fh.read()
+    data = json.loads(content)
+    yield from data.get("features", [])
+
+
+def iter_features(path: Path) -> Iterator[dict]:
+    try:
+        import ijson  # noqa: F401, PLC0415
+        yield from _iter_features_ijson(path)
+    except ImportError:
+        yield from _iter_features_stdlib(path)
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+def process(input_path: Path, output_path: Path) -> int:
+    """
+    Stream-process input GeoJSON, write normalized GeoJSONSeq to output_path.
+
+    Returns 0 on success, 1 if any unmapped non-urban crop values were found.
+    """
+    unmapped: Counter = Counter()
+    total = 0
+
+    with output_path.open("w", encoding="utf-8") as out_fh:
+        for feature in iter_features(input_path):
+            total += 1
+            raw_props = feature.get("properties") or {}
+            try:
+                norm_props = normalize_feature(raw_props)
+            except ValueError as exc:
+                raw_val = str(raw_props.get("main_crop", "")).strip()
+                unmapped[raw_val] += 1
+                continue
+
+            out_feature = {
+                "type": "Feature",
+                "geometry": feature.get("geometry"),
+                "properties": norm_props,
+            }
+            out_fh.write(json.dumps(out_feature, ensure_ascii=False) + "\n")
+
+    written = total - sum(unmapped.values())
+    print(f"Processed {total} features: {written} written, {sum(unmapped.values())} skipped.")
+
+    if unmapped:
+        print("ERROR: unmapped non-urban main_crop values:", file=sys.stderr)
+        for val, count in unmapped.most_common():
+            print(f"  {val!r}: {count} feature(s)", file=sys.stderr)
+        return 1
+
+    print("Coverage check: PASSED (0 unmapped non-urban values)")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Normalize LandIQ 2024 GeoJSON for Mapbox tileset ingestion."
+    )
+    parser.add_argument("input", type=Path, help="Path to source GeoJSON (FeatureCollection)")
+    parser.add_argument("output", type=Path, help="Path for output GeoJSONSeq (.geojsons)")
+    args = parser.parse_args()
+
+    if not args.input.exists():
+        print(f"ERROR: input file not found: {args.input}", file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(process(args.input, args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_preprocess_landiq.py
+++ b/scripts/test_preprocess_landiq.py
@@ -1,0 +1,158 @@
+"""Tests for scripts/preprocess_landiq.py -- run with: pytest scripts/test_preprocess_landiq.py -v"""
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent / "preprocess_landiq.py"
+
+# ---------------------------------------------------------------------------
+# Import the module under test (direct import, not subprocess, for unit tests)
+# ---------------------------------------------------------------------------
+import importlib.util
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("preprocess_landiq", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _normalize(mod, main_crop, acres=10.0, county="fresno", resources=None):
+    """Helper: call mod.normalize_feature() with a minimal input properties dict."""
+    props = {"main_crop": main_crop, "acres": acres, "county": county}
+    if resources is not None:
+        props["resources"] = resources
+    return mod.normalize_feature(props)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for normalize_feature()
+# ---------------------------------------------------------------------------
+
+class TestNormalizeFeature:
+    def setup_method(self):
+        self.mod = _load_module()
+
+    def test_lowercase_to_canonical_almonds(self):
+        out = _normalize(self.mod, "almonds")
+        assert out["main_crop_name"] == "Almonds"
+        assert out["main_crop_code"] == ""
+
+    def test_lowercase_to_canonical_corn(self):
+        out = _normalize(self.mod, "corn, sorghum and sudan")
+        assert out["main_crop_name"] == "Corn, Sorghum and Sudan"
+
+    def test_lowercase_to_canonical_sugar_beets(self):
+        # "Sugar beets" has mixed case -- verify auto-correct via lower() round-trip
+        out = _normalize(self.mod, "sugar beets")
+        assert out["main_crop_name"] == "Sugar beets"
+
+    def test_citrus_special_case(self):
+        # "citrus" does NOT match "citrus and subtropical" -- needs explicit override
+        out = _normalize(self.mod, "citrus")
+        assert out["main_crop_name"] == "Citrus and Subtropical"
+        assert out["main_crop_code"] == ""
+
+    def test_urban_u(self):
+        out = _normalize(self.mod, "u")
+        assert out["main_crop_code"] == "U"
+        assert out["main_crop_name"] == "Unclassified"
+
+    def test_urban_ul2(self):
+        out = _normalize(self.mod, "ul2")
+        assert out["main_crop_code"] == "U"
+        assert out["main_crop_name"] == "Unclassified"
+
+    def test_passthrough_fields(self):
+        out = _normalize(self.mod, "almonds", acres=45.3, county="kern")
+        assert out["acres"] == 45.3
+        assert out["county"] == "kern"
+
+    def test_resources_pipe_encoding(self):
+        out = _normalize(self.mod, "almonds", resources=["almond hulls", "almond shells"])
+        assert out["resources"] == "almond hulls|almond shells"
+
+    def test_null_resources_omitted(self):
+        out = _normalize(self.mod, "almonds", resources=None)
+        # property dict passed has no 'resources' key (None means not passed)
+        assert "resources" not in out
+
+    def test_empty_resources_omitted(self):
+        out = _normalize(self.mod, "almonds", resources=[])
+        assert "resources" not in out
+
+    def test_masked_county_passthrough(self):
+        out = _normalize(self.mod, "almonds", county="****")
+        assert out["county"] == "****"
+
+    def test_no_geoid_in_output(self):
+        props = {"main_crop": "almonds", "acres": 5.0, "county": "fresno", "geoid": "06019", "tileset_id": "abc"}
+        out = self.mod.normalize_feature(props)
+        assert "geoid" not in out
+        assert "tileset_id" not in out
+
+
+# ---------------------------------------------------------------------------
+# Abort test: unknown crop value must cause exit code 1
+# ---------------------------------------------------------------------------
+
+class TestUnknownCropAborts:
+    def test_unknown_crop_exits_nonzero(self, tmp_path):
+        # Build a tiny GeoJSON file with one unknown crop
+        feature = {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [0, 0]},
+            "properties": {"main_crop": "unknown_crop_xyz", "acres": 1.0, "county": "test"}
+        }
+        fc = {"type": "FeatureCollection", "features": [feature]}
+        infile = tmp_path / "test_input.geojson"
+        outfile = tmp_path / "test_output.geojsons"
+        infile.write_text(json.dumps(fc))
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), str(infile), str(outfile)],
+            capture_output=True, text=True
+        )
+        assert result.returncode != 0, "Expected non-zero exit for unknown crop"
+
+    def test_known_crop_exits_zero(self, tmp_path):
+        feature = {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [0, 0]},
+            "properties": {"main_crop": "almonds", "acres": 1.0, "county": "fresno"}
+        }
+        fc = {"type": "FeatureCollection", "features": [feature]}
+        infile = tmp_path / "test_input.geojson"
+        outfile = tmp_path / "test_output.geojsons"
+        infile.write_text(json.dumps(fc))
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), str(infile), str(outfile)],
+            capture_output=True, text=True
+        )
+        assert result.returncode == 0, f"Expected exit 0 for known crop; stderr: {result.stderr}"
+
+    def test_output_is_valid_geojsonseq(self, tmp_path):
+        features = [
+            {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]},
+             "properties": {"main_crop": "almonds", "acres": 5.0, "county": "fresno",
+                            "resources": ["almond hulls", "almond shells"]}},
+            {"type": "Feature", "geometry": {"type": "Point", "coordinates": [1, 1]},
+             "properties": {"main_crop": "u", "acres": 10.0, "county": "los angeles"}},
+        ]
+        fc = {"type": "FeatureCollection", "features": features}
+        infile = tmp_path / "in.geojson"
+        outfile = tmp_path / "out.geojsons"
+        infile.write_text(json.dumps(fc))
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), str(infile), str(outfile)],
+            capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr
+        lines = outfile.read_text().strip().split("\n")
+        assert len(lines) == 2
+        f1 = json.loads(lines[0])
+        assert f1["properties"]["main_crop_name"] == "Almonds"
+        assert f1["properties"]["resources"] == "almond hulls|almond shells"
+        f2 = json.loads(lines[1])
+        assert f2["properties"]["main_crop_code"] == "U"

--- a/scripts/upload-landiq-tileset.ts
+++ b/scripts/upload-landiq-tileset.ts
@@ -100,20 +100,24 @@ async function publishTileset(token: string): Promise<string> {
 async function pollUntilComplete(token: string, jobId: string): Promise<void> {
   console.log('Step 4: Polling for publish status ...');
   const maxAttempts = 90; // 15 minutes at 10s intervals
+  const [username, tilesetName] = TILESET_ID.split('.');
   for (let i = 0; i < maxAttempts; i++) {
     await new Promise(resolve => setTimeout(resolve, 10000));
-    const res = await fetch(apiUrl(`/tilesets/v1/${TILESET_ID}/status`, token));
+    // Use the list endpoint to check status (detail endpoint requires tilesets:read scope)
+    const res = await fetch(apiUrl(`/tilesets/v1/${username}`, token));
     if (!res.ok) {
       console.warn(`  Status check failed (${res.status}), retrying...`);
       continue;
     }
-    const data = await res.json() as { status: string; jobId?: string };
-    console.log(`  Status: ${data.status} (attempt ${i + 1}/${maxAttempts})`);
-    if (data.status === 'success') {
+    const tilesets = await res.json() as Array<{ id: string; status: string }>;
+    const entry = tilesets.find(t => t.id === TILESET_ID);
+    const status = entry?.status ?? 'unknown';
+    console.log(`  Status: ${status} (attempt ${i + 1}/${maxAttempts})`);
+    if (status === 'available') {
       console.log(`  Tileset published successfully. Job ID: ${jobId}`);
       return;
     }
-    if (data.status === 'failed') {
+    if (status === 'failed') {
       console.error('  Tileset publish failed. Check Mapbox Studio for error details.');
       process.exit(1);
     }

--- a/scripts/upload-landiq-tileset.ts
+++ b/scripts/upload-landiq-tileset.ts
@@ -1,0 +1,160 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const TILESET_ID = 'sustainasoft.landiq-cropland-2026-06';
+const SOURCE_ID = 'landiq_cropland_2024';
+const SOURCE_LAYER = 'cropland_land_iq'; // stable name; must match tileset-registry.ts
+const SOURCE_NAME = `mapbox://tileset-source/sustainasoft/${SOURCE_ID}`;
+const BASE_URL = 'https://api.mapbox.com';
+// Default output from preprocess_landiq.py; can override via LANDIQ_GEOJSONS env var
+const GEOJSONS_PATH = process.env.LANDIQ_GEOJSONS ?? path.join(process.cwd(), 'landiq_2024_normalized.geojsons');
+
+function apiUrl(apiPath: string, token: string): string {
+  return `${BASE_URL}${apiPath}?access_token=${token}`;
+}
+
+export function buildRecipe(): object {
+  return {
+    version: 1,
+    layers: {
+      [SOURCE_LAYER]: {
+        source: SOURCE_NAME,
+        minzoom: 5,
+        maxzoom: 14,
+      },
+    },
+  };
+}
+
+async function uploadTilesetSource(token: string): Promise<void> {
+  console.log(`Step 1: Uploading tileset source from ${path.basename(GEOJSONS_PATH)} ...`);
+  const fileData = fs.readFileSync(GEOJSONS_PATH);
+  const formData = new FormData();
+  formData.append('file', new Blob([fileData], { type: 'application/x-ndjson' }), `${SOURCE_ID}.geojsons`);
+
+  const res = await fetch(apiUrl(`/tilesets/v1/sources/sustainasoft/${SOURCE_ID}`, token), {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!res.ok && res.status !== 409) {
+    const body = await res.text();
+    throw new Error(`Source upload failed (${res.status}): ${body}`);
+  }
+  if (res.status === 409) {
+    console.log('  Source already exists -- will overwrite via re-publish.');
+  } else {
+    console.log('  Source uploaded successfully.');
+  }
+}
+
+async function createOrUpdateTileset(token: string): Promise<void> {
+  console.log(`Step 2: Creating/updating tileset ${TILESET_ID} ...`);
+  const recipe = buildRecipe();
+
+  // Use POST to create; if already exists (409) patch the recipe instead
+  const createRes = await fetch(apiUrl(`/tilesets/v1/${TILESET_ID}`, token), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ recipe, name: 'Cal BioScape LandIQ 2024 Cropland' }),
+  });
+
+  if (createRes.status === 409) {
+    console.log('  Tileset already exists, patching recipe ...');
+    const patchRes = await fetch(apiUrl(`/tilesets/v1/${TILESET_ID}/recipe`, token), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(recipe),
+    });
+    if (!patchRes.ok) {
+      const text = await patchRes.text();
+      throw new Error(`Recipe patch failed (${patchRes.status}): ${text}`);
+    }
+    console.log('  Recipe patched successfully.');
+  } else if (!createRes.ok) {
+    const text = await createRes.text();
+    throw new Error(`Tileset create failed (${createRes.status}): ${text}`);
+  } else {
+    console.log('  Tileset created successfully.');
+  }
+}
+
+async function publishTileset(token: string): Promise<string> {
+  console.log(`Step 3: Publishing ${TILESET_ID} ...`);
+  const res = await fetch(apiUrl(`/tilesets/v1/${TILESET_ID}/publish`, token), { method: 'POST' });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Publish failed (${res.status}): ${text}`);
+  }
+
+  const data = await res.json() as { jobId?: string };
+  const jobId = data.jobId ?? 'unknown';
+  console.log(`  Publish started. Job ID: ${jobId}`);
+  return jobId;
+}
+
+async function pollUntilComplete(token: string, jobId: string): Promise<void> {
+  console.log('Step 4: Polling for publish status ...');
+  const maxAttempts = 90; // 15 minutes at 10s intervals
+  for (let i = 0; i < maxAttempts; i++) {
+    await new Promise(resolve => setTimeout(resolve, 10000));
+    const res = await fetch(apiUrl(`/tilesets/v1/${TILESET_ID}/status`, token));
+    if (!res.ok) {
+      console.warn(`  Status check failed (${res.status}), retrying...`);
+      continue;
+    }
+    const data = await res.json() as { status: string; jobId?: string };
+    console.log(`  Status: ${data.status} (attempt ${i + 1}/${maxAttempts})`);
+    if (data.status === 'success') {
+      console.log(`  Tileset published successfully. Job ID: ${jobId}`);
+      return;
+    }
+    if (data.status === 'failed') {
+      console.error('  Tileset publish failed. Check Mapbox Studio for error details.');
+      process.exit(1);
+    }
+  }
+  console.error('Timed out waiting for tileset publish (15 min). Check Mapbox Studio.');
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const token = process.env.MAPBOX_SECRET_TOKEN;
+  if (!token) {
+    console.error('MAPBOX_SECRET_TOKEN is not set.');
+    console.error('Get it with: export MAPBOX_SECRET_TOKEN=$(gcloud secrets versions access latest --secret=mapbox-secret-token --project=biocirv-470318)');
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(GEOJSONS_PATH)) {
+    console.error(`Preprocessed GeoJSONSeq not found: ${GEOJSONS_PATH}`);
+    console.error('Run first: python scripts/preprocess_landiq.py <input.geojson> landiq_2024_normalized.geojsons');
+    process.exit(1);
+  }
+
+  const sizeMB = (fs.statSync(GEOJSONS_PATH).size / 1024 / 1024).toFixed(1);
+  console.log(`\nUploading LandIQ 2024 cropland tileset to sustainasoft Mapbox account`);
+  console.log(`Tileset ID   : ${TILESET_ID}`);
+  console.log(`Source layer : ${SOURCE_LAYER}`);
+  console.log(`Source file  : ${GEOJSONS_PATH} (${sizeMB} MB)\n`);
+
+  await uploadTilesetSource(token);
+  await createOrUpdateTileset(token);
+  const jobId = await publishTileset(token);
+  await pollUntilComplete(token, jobId);
+
+  console.log('\nDone! Tileset is live on the sustainasoft Mapbox account.');
+  console.log(`Verify in Studio: https://studio.mapbox.com/tilesets/${TILESET_ID}`);
+}
+
+const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop()!);
+if (isMain) {
+  main().catch(err => {
+    console.error('Fatal error:', err.message);
+    process.exit(1);
+  });
+}

--- a/src/lib/tileset-registry.ts
+++ b/src/lib/tileset-registry.ts
@@ -28,7 +28,7 @@ export interface TilesetConfig {
 export const DEFAULT_TILESET_REGISTRY: Record<string, TilesetConfig> = {
   // FEEDSTOCK LAYERS
   feedstock: {
-    tilesetId: 'sustainasoft.cal-bioscape-landiq-cropland-2026-06',
+    tilesetId: 'sustainasoft.landiq-cropland-2026-06',
     sourceLayer: 'cropland_land_iq',
     displayName: 'Crop Residues',
     category: 'feedstock',

--- a/src/lib/tileset-registry.ts
+++ b/src/lib/tileset-registry.ts
@@ -28,12 +28,12 @@ export interface TilesetConfig {
 export const DEFAULT_TILESET_REGISTRY: Record<string, TilesetConfig> = {
   // FEEDSTOCK LAYERS
   feedstock: {
-    tilesetId: 'tylerhuntington222.cropland_landiq_2023', // TODO: Update to sustainasoft.cal-bioscape-landiq-cropland-YYYY-MM
-    sourceLayer: 'cropland_land_iq_2023', // TODO: Backend should use stable name: cropland_land_iq
+    tilesetId: 'sustainasoft.cal-bioscape-landiq-cropland-2026-06',
+    sourceLayer: 'cropland_land_iq',
     displayName: 'Crop Residues',
     category: 'feedstock',
-    version: 'current',
-    accountType: 'legacy'
+    version: '2026-06',
+    accountType: 'default'
   },
 
   // County boundary layer -- CA counties from US Atlas (simplified TopoJSON converted to GeoJSON).


### PR DESCRIPTION
**Plan doc:** https://lbl.github.com/sustainability-software-lab/cal-bioscape-frontend/blob/61359bdf527f890fdffa05effda56f0336a8c5bb/docs/LANDIQ_2024_INTEGRATION_PLAN.md

Adds the LandIQ 2024 cropland integration plan to the repo as a permanent reference.

This branch will also carry the Workstream 1 implementation (Phases A, D, E):
- Streaming GeoJSON preprocessing script
- Frontend tileset registry wiring
- Tileset specification docs update
