### PR TITLE
fix: correct CARB tileset ID and upload script for Mapbox API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ Create `.env.local` for local development. Never commit secrets.
 | `GITHUB_REPO_NAME` | No | GitHub repo name, e.g. `cal-bioscape-frontend` |
 | `GITHUB_ISSUE_CREATE_ENABLED` | No | Must be `"true"` to activate GitHub issue creation |
 | `GITHUB_BASE_URL` | No | Override for GitHub Enterprise API, e.g. `https://lbl.github.com/api/v3` |
-| `MAPBOX_SECRET_TOKEN` | CLI only | sustainasoft `sk.*` Mapbox token with `tilesets:write` and `tilesets:read` scopes; used by `npm run upload-carb-tileset` to publish the CARB food processors tileset; never `NEXT_PUBLIC_` |
+| `MAPBOX_SECRET_TOKEN` | CLI only | sustainasoft `sk.*` Mapbox token with `tilesets:write` and `tilesets:read` scopes; used by `npm run upload-carb-tileset` to publish the CARB food processors tileset; never `NEXT_PUBLIC_`; stored in GCP Secret Manager as `mapbox-secret-token` (project biocirv-470318) |
 
 **Auth mode selection**: Deployed staging and production services should set `CA_BIOSITE_API_KEY`. If it is set, the proxy sends `X-API-Key: <key>` and never retries on 401. If only username/password are set, the proxy uses the legacy OAuth2 JWT fallback with one retry on 401.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,7 @@ Create `.env.local` for local development. Never commit secrets.
 | `GITHUB_REPO_NAME` | No | GitHub repo name, e.g. `cal-bioscape-frontend` |
 | `GITHUB_ISSUE_CREATE_ENABLED` | No | Must be `"true"` to activate GitHub issue creation |
 | `GITHUB_BASE_URL` | No | Override for GitHub Enterprise API, e.g. `https://lbl.github.com/api/v3` |
-| `MAPBOX_SECRET_TOKEN` | CLI only | sustainasoft `sk.*` Mapbox token with `tilesets:write` and `tilesets:read` scopes; used by `npm run upload-carb-tileset` to publish the CARB food processors tileset; never `NEXT_PUBLIC_`; stored in GCP Secret Manager as `mapbox-secret-token` (project biocirv-470318) |
+| `MAPBOX_SECRET_TOKEN` | CLI only | sustainasoft `sk.*` Mapbox token with `tilesets:write` and `tilesets:read` scopes; used by `npm run upload-carb-tileset` to publish the CARB food processors tileset; never `NEXT_PUBLIC_`; stored in GCP Secret Manager as `mapbox-secret-token` (project biocirv-470318); fetch with `export MAPBOX_SECRET_TOKEN=$(gcloud secrets versions access latest --secret=mapbox-secret-token --project=biocirv-470318)` |
 
 **Auth mode selection**: Deployed staging and production services should set `CA_BIOSITE_API_KEY`. If it is set, the proxy sends `X-API-Key: <key>` and never retries on 401. If only username/password are set, the proxy uses the legacy OAuth2 JWT fallback with one retry on 401.
 

--- a/docs/CARB_FOOD_PROCESSORS_PIPELINE.md
+++ b/docs/CARB_FOOD_PROCESSORS_PIPELINE.md
@@ -47,4 +47,11 @@ When the source CSV is updated:
 
 ## Environment variable
 
-`MAPBOX_SECRET_TOKEN` -- sustainasoft `sk.*` Mapbox token with `tilesets:write` and `tilesets:read` scopes. Server/CLI-only; never expose as `NEXT_PUBLIC_`. Add to your local `.env` for development.
+`MAPBOX_SECRET_TOKEN` -- sustainasoft `sk.*` Mapbox token with `tilesets:write` and `tilesets:read` scopes. Server/CLI-only; never expose as `NEXT_PUBLIC_`.
+
+Stored in GCP Secret Manager: `mapbox-secret-token` (project `biocirv-470318`).
+
+To fetch it locally:
+```bash
+export MAPBOX_SECRET_TOKEN=$(gcloud secrets versions access latest --secret=mapbox-secret-token --project=biocirv-470318)
+```

--- a/docs/CARB_FOOD_PROCESSORS_PIPELINE.md
+++ b/docs/CARB_FOOD_PROCESSORS_PIPELINE.md
@@ -6,7 +6,7 @@ Pipeline for converting the CARB food processors CSV into a Mapbox tileset and r
 
 | Item | Value |
 |---|---|
-| Tileset ID | `sustainasoft.cal-bioscape-carb-food-processors-2026-06` |
+| Tileset ID | `sustainasoft.carb-food-processors-2026-06` |
 | Source layer | `carb_food_processors` |
 | Source CSV | `src/data/food_manufacturers_and_processor_facilities_carb.csv` |
 | App visibility key | `carbFoodProcessors` |

--- a/scripts/upload-carb-tileset.ts
+++ b/scripts/upload-carb-tileset.ts
@@ -57,7 +57,7 @@ async function createOrUpdateTileset(token: string): Promise<void> {
   const createRes = await fetch(apiUrl(`/tilesets/v1/${TILESET_ID}`, token), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ recipe, name: 'CARB Food Processors (Cal BioScape 2026-06)' }),
+    body: JSON.stringify({ recipe, name: 'CARB Food Processors Cal BioScape 2026-06' }),
   });
 
   if (createRes.status === 409) {

--- a/scripts/upload-carb-tileset.ts
+++ b/scripts/upload-carb-tileset.ts
@@ -4,7 +4,7 @@ import * as dotenv from 'dotenv';
 
 dotenv.config();
 
-const TILESET_ID = 'sustainasoft.cal-bioscape-carb-food-processors-2026-06';
+const TILESET_ID = 'sustainasoft.carb-food-processors-2026-06';
 const SOURCE_ID = 'carb_food_processors';
 const SOURCE_NAME = `mapbox://tileset-source/sustainasoft/${SOURCE_ID}`;
 const BASE_URL = 'https://api.mapbox.com';
@@ -52,22 +52,31 @@ async function uploadTilesetSource(token: string): Promise<void> {
 async function createOrUpdateTileset(token: string): Promise<void> {
   console.log(`Step 2: Creating/updating tileset ${TILESET_ID}...`);
   const recipe = buildRecipe();
-  const body = { recipe, name: 'CARB Food Processors (Cal BioScape 2026-06)' };
 
-  const res = await fetch(apiUrl(`/tilesets/v1/${TILESET_ID}`, token), {
-    method: 'PUT',
+  // Try to create (POST); if it already exists (409) patch the recipe instead
+  const createRes = await fetch(apiUrl(`/tilesets/v1/${TILESET_ID}`, token), {
+    method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body: JSON.stringify({ recipe, name: 'CARB Food Processors (Cal BioScape 2026-06)' }),
   });
 
-  if (!res.ok && res.status !== 422) {
-    const text = await res.text();
-    throw new Error(`Tileset create/update failed (${res.status}): ${text}`);
-  }
-  if (res.status === 422) {
-    console.log('  Tileset already exists, recipe will be updated via publish...');
+  if (createRes.status === 409) {
+    console.log('  Tileset already exists, patching recipe...');
+    const patchRes = await fetch(apiUrl(`/tilesets/v1/${TILESET_ID}/recipe`, token), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(recipe),
+    });
+    if (!patchRes.ok) {
+      const text = await patchRes.text();
+      throw new Error(`Recipe patch failed (${patchRes.status}): ${text}`);
+    }
+    console.log('  Recipe patched successfully.');
+  } else if (!createRes.ok) {
+    const text = await createRes.text();
+    throw new Error(`Tileset create failed (${createRes.status}): ${text}`);
   } else {
-    console.log('  Tileset created/updated successfully.');
+    console.log('  Tileset created successfully.');
   }
 }
 

--- a/src/lib/tileset-registry.ts
+++ b/src/lib/tileset-registry.ts
@@ -164,7 +164,7 @@ export const DEFAULT_TILESET_REGISTRY: Record<string, TilesetConfig> = {
   },
 
   carbFoodProcessors: {
-    tilesetId: 'sustainasoft.cal-bioscape-carb-food-processors-2026-06',
+    tilesetId: 'sustainasoft.carb-food-processors-2026-06',
     sourceLayer: 'carb_food_processors',
     displayName: 'Food Processing Facilities (CARB)',
     category: 'infrastructure',


### PR DESCRIPTION
## Summary

Follow-up fixes to the initial CARB food processors implementation (epic #64).

- **Tileset ID corrected**: Mapbox tileset names have a 32-char max. The original ID `cal-bioscape-carb-food-processors-2026-06` was 41 chars. Renamed to `carb-food-processors-2026-06` (28 chars), so the full ID is `sustainasoft.carb-food-processors-2026-06`. This matches what was actually published to Mapbox.
- **Upload script**: Changed tileset creation from `PUT` to `POST` (correct Mapbox MTS API method), with `PATCH /recipe` fallback on 409. Removed parentheses from display name (not allowed by Mapbox API).
- **Docs**: Added `mapbox-secret-token` GCP Secret Manager reference and gcloud fetch command to AGENTS.md and pipeline docs.

## Test plan

- [x] `npm test` -- 48 tests pass
- [x] `npx tsc --noEmit` -- no TypeScript errors
- [x] Tileset successfully published to `sustainasoft.carb-food-processors-2026-06` (verified in Mapbox account)
