### PR TITLE
feat(county): speed up popup load, hover shading, thin borders, clearer empty state

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -30,7 +30,11 @@ async function proxyRequest(
 
   const contentType = res.headers.get('content-type') ?? '';
   if (contentType.includes('application/json')) {
-    return NextResponse.json(await res.json(), { status: res.status });
+    const response = NextResponse.json(await res.json(), { status: res.status });
+    if (res.status >= 200 && res.status < 300) {
+      response.headers.set('Cache-Control', 'public, max-age=86400, stale-while-revalidate=604800');
+    }
+    return response;
   }
   return new NextResponse(res.body, { status: res.status });
 }

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1322,7 +1322,7 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
         try {
           if (isCountyGeoJson) {
             const geojsonPath = countyTilesetId.slice('geojson://'.length); // e.g. '/ca-counties.geojson'
-            map.current.addSource('county-source', { type: 'geojson', data: geojsonPath });
+            map.current.addSource('county-source', { type: 'geojson', data: geojsonPath, promoteId: 'GEOID' });
           } else {
             map.current.addSource('county-source', {
               type: 'vector',
@@ -1342,7 +1342,7 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             },
             paint: {
               'fill-color': '#3B82F6',
-              'fill-opacity': 0.15
+              'fill-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 0.35, 0.15]
             }
           });
           map.current.addLayer({
@@ -1354,7 +1354,7 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             },
             paint: {
               'line-color': '#1D4ED8',
-              'line-width': 1.5
+              'line-width': ['case', ['boolean', ['feature-state', 'hover'], false], 1.5, 0.5]
             }
           });
         } catch(countyErr) { console.error('[county] init failed:', countyErr.message); }
@@ -1393,7 +1393,7 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             if (currentPopup.current !== popup || popup._countyRequestId !== requestId) return;
 
             if (!aggregates || aggregates.cropsCounted === 0) {
-              popup.setHTML(`<div class="county-popup"><strong>${name} County</strong><br/><em>No county data available.</em></div>`);
+              popup.setHTML(`<div class="county-popup"><strong>${name} County</strong><br/><em>No USDA cropland reported for this county.</em></div>`);
               return;
             }
 
@@ -1415,17 +1415,30 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             `);
           } catch {
             if (currentPopup.current === popup) {
-              popup.setHTML(`<div class="county-popup"><strong>${name} County</strong><br/><em>No county data available.</em></div>`);
+              popup.setHTML(`<div class="county-popup"><strong>${name} County</strong><br/><em>Couldn't load county data -- please try again.</em></div>`);
             }
           }
         });
 
-        // Cursor handling for county layer
-        map.current.on('mouseenter', 'county-layer', () => {
+        // Hover shading + pointer cursor for county layer
+        let hoveredCountyId = null;
+        map.current.on('mousemove', 'county-layer', (e) => {
           map.current.getCanvas().style.cursor = 'pointer';
+          const feature = e.features && e.features[0];
+          if (!feature) return;
+          const id = feature.id ?? feature.properties.GEOID;
+          if (hoveredCountyId !== null && hoveredCountyId !== id) {
+            map.current.setFeatureState({ source: 'county-source', id: hoveredCountyId }, { hover: false });
+          }
+          hoveredCountyId = id;
+          map.current.setFeatureState({ source: 'county-source', id }, { hover: true });
         });
         map.current.on('mouseleave', 'county-layer', () => {
           map.current.getCanvas().style.cursor = '';
+          if (hoveredCountyId !== null) {
+            map.current.setFeatureState({ source: 'county-source', id: hoveredCountyId }, { hover: false });
+            hoveredCountyId = null;
+          }
         });
 
         // Persistent siting buffer source and layers

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -38,7 +38,7 @@ export class ApiAuthError extends Error {
 async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T | null> {
   try {
     const url = `/api/proxy${path}`;
-    const res = await fetch(url, { cache: 'no-store' });
+    const res = await fetch(url, { cache: 'default' });
 
     if (!res.ok) {
       if (options.throwOnAuthError && (res.status === 401 || res.status === 403)) {

--- a/src/lib/county-analysis.ts
+++ b/src/lib/county-analysis.ts
@@ -2,6 +2,24 @@
  * County-level feedstock statistics fetched from the USDA census/survey API.
  */
 
+/**
+ * Creates a keyed promise cache. Concurrent calls with the same key share one promise.
+ * Rejected promises are evicted so the next call can retry.
+ */
+export function makePromiseCache<T>(
+  factory: (key: string) => Promise<T>
+): (key: string) => Promise<T> {
+  const cache = new Map<string, Promise<T>>();
+  return (key: string) => {
+    const cached = cache.get(key);
+    if (cached) return cached;
+    const p = factory(key);
+    cache.set(key, p);
+    p.catch(() => cache.delete(key));
+    return p;
+  };
+}
+
 import { ApiAuthError, getCensusByResource, getSurveyByResource } from './api';
 import { DataItemResponse } from './api-types';
 import { LANDIQ_TO_API_RESOURCE } from './resource-mapping';
@@ -287,11 +305,7 @@ export function computeCountyAggregates(
   };
 }
 
-/**
- * Async orchestrator: fetches county feedstock stats then computes aggregates
- * using live residue factors and composition fallbacks.
- */
-export async function getCountyAggregateStats(geoid: string): Promise<CountyAggregates | null> {
+async function computeCountyAggregateStats(geoid: string): Promise<CountyAggregates | null> {
   const stats = await fetchCountyFeedstockStats(geoid);
   if (stats.length === 0) return null;
 
@@ -316,3 +330,7 @@ export async function getCountyAggregateStats(geoid: string): Promise<CountyAggr
 
   return computeCountyAggregates(stats, residueLookup, compositionLookup);
 }
+
+// Session-scoped in-memory cache: USDA data is static, so a second click on any
+// county is instant. Rejected entries are evicted so retries are possible.
+export const getCountyAggregateStats = makePromiseCache(computeCountyAggregateStats);

--- a/tests/promise-cache.test.ts
+++ b/tests/promise-cache.test.ts
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { makePromiseCache } from '../src/lib/county-analysis';
+
+test('promise cache deduplicates concurrent calls with the same key', async () => {
+  let callCount = 0;
+  const cache = makePromiseCache(async (key: string) => {
+    callCount++;
+    return key + '-result';
+  });
+
+  const [a, b] = await Promise.all([cache('x'), cache('x')]);
+
+  assert.equal(callCount, 1, 'factory should only be called once for concurrent same-key calls');
+  assert.equal(a, 'x-result');
+  assert.equal(b, 'x-result');
+});
+
+test('promise cache serves repeat calls from cache without re-invoking factory', async () => {
+  let callCount = 0;
+  const cache = makePromiseCache(async (key: string) => {
+    callCount++;
+    return callCount;
+  });
+
+  await cache('y');
+  const second = await cache('y');
+
+  assert.equal(callCount, 1, 'factory should not be called again for a cached key');
+  assert.equal(second, 1);
+});
+
+test('promise cache evicts rejected entries so subsequent calls retry', async () => {
+  let callCount = 0;
+  const cache = makePromiseCache(async (_key: string) => {
+    callCount++;
+    if (callCount === 1) throw new Error('first call fails');
+    return 'success';
+  });
+
+  await assert.rejects(() => cache('z'), /first call fails/);
+
+  // After rejection, cache should be clear -- next call must retry
+  const result = await cache('z');
+  assert.equal(callCount, 2, 'factory should be called again after rejection');
+  assert.equal(result, 'success');
+});


### PR DESCRIPTION
## Summary

- **In-memory promise cache** (`makePromiseCache`) wraps `getCountyAggregateStats` -- repeat clicks on the same county are instant (promise shared/cached by geoid); concurrent clicks deduplicate. Rejections evict from cache so retries work.
- **Proxy HTTP caching** -- successful JSON GET responses from `/api/proxy` now carry `Cache-Control: public, max-age=86400, stale-while-revalidate=604800`, and `apiFetch` cache mode changed from `no-store` to `default` so the browser HTTP cache actually stores these responses.
- **Hover shading** -- county GeoJSON source gains `promoteId: 'GEOID'` to enable feature-state; fill-opacity and line-width are now driven by a `hover` feature-state expression. `mouseenter`/`mouseleave` cursor handlers replaced with `mousemove`/`mouseleave` that track `hoveredCountyId` and call `setFeatureState`.
- **Thinner borders** -- resting `line-width` drops from 1.5 to 0.5; bumps to 1.5 on hover.
- **Clearer empty state** -- "No county data available." replaced with "No USDA cropland reported for this county." for genuinely empty counties. Error catch message is now distinct: "Couldn't load county data -- please try again."

## Files changed

- `src/lib/county-analysis.ts` -- `makePromiseCache` helper + session cache on `getCountyAggregateStats`
- `src/app/api/proxy/[...path]/route.ts` -- `Cache-Control` on 2xx JSON responses
- `src/lib/api.ts` -- `cache: 'default'` in `apiFetch`
- `src/components/Map.js` -- `promoteId`, feature-state fill/border, hover handlers, popup copy
- `tests/promise-cache.test.ts` -- 3 unit tests for cache dedup, cache hit, rejection eviction

## Test plan

- [x] All 59 unit tests pass (`npx tsx --test tests/*.test.ts` -- 0 failures)
- [x] `npm run build` passes (TypeScript clean, Next.js build succeeds)
- [x] Open the app, enable County Level Stats layer
- [x] Hover over a county: fill shades blue, borders thin; shading follows cursor and clears on leave
- [x] Click Fresno County: popup loads with stats table; click again (same session): popup is instant (memory cache)
- [x] Click Tuolumne County (low-ag): popup reads "No USDA cropland reported for this county." -- not error-looking
- [x] Reload page, re-click a previously-seen county: DevTools shows "from disk cache" for `/api/proxy` calls
- [x] Network tab confirms repeat same-session clicks issue zero new `/api/proxy` requests

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)