### PR TITLE
fix(county): throttle concurrent feedstock requests and add 503 retry (#85)

### DIFF
--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -5,10 +5,15 @@ const BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL ??
   'https://api.calbioscape.org';
 
+// Maximum 503 retry attempts (cold-start on Cloud Run).
+const MAX_503_RETRIES = 2;
+const RETRY_DELAY_MS = 300;
+
 async function proxyRequest(
   req: NextRequest,
   path: string[],
-  isRetry = false
+  isRetry = false,
+  retries503 = MAX_503_RETRIES
 ): Promise<NextResponse> {
   const token = await getServiceToken();
   const search = req.nextUrl.search;
@@ -25,7 +30,14 @@ async function proxyRequest(
   // A revoked API key will never recover with the same credential.
   if (res.status === 401 && !isRetry && !isApiKeyAuth()) {
     invalidateServiceToken();
-    return proxyRequest(req, path, true);
+    return proxyRequest(req, path, true, retries503);
+  }
+
+  // Retry 503 (service unavailable / cold-start) with exponential backoff.
+  if (res.status === 503 && retries503 > 0) {
+    const delay = RETRY_DELAY_MS * (MAX_503_RETRIES - retries503 + 1);
+    await new Promise(resolve => setTimeout(resolve, delay));
+    return proxyRequest(req, path, isRetry, retries503 - 1);
   }
 
   const contentType = res.headers.get('content-type') ?? '';

--- a/src/lib/county-analysis.ts
+++ b/src/lib/county-analysis.ts
@@ -168,6 +168,37 @@ export function getCountyPanelSelectionForResponse({
 }
 
 /**
+ * Concurrency-limited equivalent of Promise.allSettled.
+ *
+ * Runs up to `concurrency` tasks simultaneously. Tasks beyond the limit are
+ * deferred until a running slot frees up. Result order matches the input array.
+ */
+export async function throttledSettled<T>(
+  tasks: Array<() => Promise<T>>,
+  concurrency: number
+): Promise<PromiseSettledResult<T>[]> {
+  const results: PromiseSettledResult<T>[] = new Array(tasks.length);
+  let nextIdx = 0;
+
+  async function worker() {
+    while (nextIdx < tasks.length) {
+      const idx = nextIdx++;
+      try {
+        results[idx] = { status: 'fulfilled', value: await tasks[idx]() };
+      } catch (reason) {
+        results[idx] = { status: 'rejected', reason };
+      }
+    }
+  }
+
+  const pool = Array.from({ length: Math.min(concurrency, tasks.length) }, worker);
+  await Promise.all(pool);
+  return results;
+}
+
+const COUNTY_FETCH_CONCURRENCY = 5;
+
+/**
  * Fetch county-level USDA stats for all LandIQ-mapped resources.
  * Merges census and survey data so missing metrics can fall through per parameter.
  * Returns only crops that have at least one data point.
@@ -185,8 +216,9 @@ export async function fetchCountyFeedstockStats(
     }
   }
 
-  const results = await Promise.allSettled(
-    Array.from(resourceToName.entries()).map(async ([resource, landiqName]) => {
+  const entries = Array.from(resourceToName.entries());
+  const results = await throttledSettled(
+    entries.map(([resource, landiqName]) => async () => {
       const [censusResponse, surveyResponse] = await Promise.all([
         getCensusByResource(resource, geoid, authAwareFetch),
         getSurveyByResource(resource, geoid, authAwareFetch),
@@ -209,7 +241,8 @@ export async function fetchCountyFeedstockStats(
       return getCountyMetric(stat, 'acres') || getCountyMetric(stat, 'production')
         ? stat
         : null;
-    })
+    }),
+    COUNTY_FETCH_CONCURRENCY
   );
 
   if (results.some(r => r.status === 'rejected' && r.reason instanceof ApiAuthError)) {

--- a/tests/county-analysis.test.ts
+++ b/tests/county-analysis.test.ts
@@ -7,7 +7,66 @@ import {
   getCountyMetric,
   getDisplaySources,
   computeCountyAggregates,
+  throttledSettled,
 } from '../src/lib/county-analysis';
+
+// ---------------------------------------------------------------------------
+// throttledSettled — concurrency-limiting Promise.allSettled wrapper
+// ---------------------------------------------------------------------------
+
+test('throttledSettled returns all settled results', async () => {
+  const tasks = [1, 2, 3, 4, 5].map(n => () => Promise.resolve(n));
+  const results = await throttledSettled(tasks, 2);
+  assert.equal(results.length, 5);
+  const values = results.map(r => (r as PromiseFulfilledResult<number>).value);
+  assert.deepEqual(values, [1, 2, 3, 4, 5]);
+});
+
+test('throttledSettled preserves result order regardless of task completion timing', async () => {
+  const order: number[] = [];
+  const tasks = [30, 10, 20].map((delay, idx) => () =>
+    new Promise<number>(resolve => setTimeout(() => {
+      order.push(idx);
+      resolve(delay);
+    }, delay))
+  );
+  const results = await throttledSettled(tasks, 3);
+  const values = results.map(r => (r as PromiseFulfilledResult<number>).value);
+  // results should be in task-submission order, not completion order
+  assert.deepEqual(values, [30, 10, 20]);
+});
+
+test('throttledSettled limits max concurrent tasks to the concurrency cap', async () => {
+  let running = 0;
+  let maxObserved = 0;
+  const tasks = Array.from({ length: 10 }, () => () =>
+    new Promise<void>(resolve => {
+      running++;
+      if (running > maxObserved) maxObserved = running;
+      setTimeout(() => { running--; resolve(); }, 10);
+    })
+  );
+  await throttledSettled(tasks, 3);
+  assert.ok(
+    maxObserved <= 3,
+    `Expected max concurrency ≤ 3, got ${maxObserved}`
+  );
+});
+
+test('throttledSettled handles rejected tasks without short-circuiting remaining tasks', async () => {
+  let ran = 0;
+  const tasks = [
+    () => Promise.reject(new Error('fail')),
+    () => { ran++; return Promise.resolve(42); },
+    () => { ran++; return Promise.resolve(99); },
+  ];
+  const results = await throttledSettled(tasks, 2);
+  assert.equal(results.length, 3);
+  assert.equal(results[0].status, 'rejected');
+  assert.equal(results[1].status, 'fulfilled');
+  assert.equal(results[2].status, 'fulfilled');
+  assert.equal(ran, 2);
+});
 
 const tomatoStat: CountyCropStat = {
   landiqName: 'Tomatoes',


### PR DESCRIPTION
## Summary

- Fixes the 503 cascade when clicking a county: `fetchCountyFeedstockStats` was firing ~34 concurrent HTTP requests simultaneously, overwhelming the backend rate limiter. Now throttled to 5 resources at a time (max 10 concurrent requests).
- Adds 503 retry with linear backoff (up to 2 retries, 300/600ms) in the proxy route to handle backend cold-start transients.
- Exports `throttledSettled` from `county-analysis.ts` with 4 unit tests covering result count, order preservation, concurrency cap, and rejection isolation.

**Note:** The 401 responses are a separate operational issue -- the `biocirv-staging-frontend-api-key` GCP Secret Manager secret needs a valid API key. This PR addresses the 503 cascade that compounds the problem and would persist even after the key is fixed.

Closes #85

## Test plan

- [x] All 14 county-analysis tests pass (4 new `throttledSettled` tests + 10 existing)
- [x] Full suite: 94/95 pass (1 pre-existing failure: `carb-food-processors-build` requires `csv-parse/sync` -- unrelated to this change)
- [ ] Manual: click Fresno county on staging after rotating `biocirv-staging-frontend-api-key` secret -- verify popup shows acreage/production/residue/cellulose stats
- [ ] Manual: verify no 503 responses in DevTools Network after fix lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)