### PR TITLE
feat(county): present county layer as USDA crop totals (#97)

### DIFF
--- a/src/components/LayerControls.tsx
+++ b/src/components/LayerControls.tsx
@@ -654,7 +654,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
           <AccordionContent>
             <div className="space-y-2 pl-4">
               
-              {/* County Level Stats Toggle */}
+              {/* USDA County Crop Totals Toggle */}
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="countyLayer"
@@ -664,7 +664,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                   onCheckedChange={(checked: boolean | 'indeterminate') => directLayerToggle('county', !!checked)}
                 />
                 <Label htmlFor="countyLayer" className="flex items-center font-medium">
-                  County Level Stats
+                  USDA County Crop Totals
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>
@@ -674,6 +674,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                       </TooltipTrigger>
                       <TooltipContent side="right">
                         <p>Source: 2022 USDA Census of Agriculture</p>
+                        <p className="text-xs text-gray-400 mt-1">Primary crop production totals only. Derived residues are on the Crop Residues (LandIQ) layer.</p>
                         <p className="text-xs text-gray-400 mt-1">Mutually exclusive with Crop Residues layer</p>
                       </TooltipContent>
                     </Tooltip>

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1513,30 +1513,45 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
               return;
             }
 
-            const avgCelluloseStr = isNaN(aggregates.avgCelluloseContent)
-              ? 'N/A'
-              : `${aggregates.avgCelluloseContent.toFixed(1)}%`;
-
-            const escapedName = name.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-            const topCrop = aggregates.topCropsByAcreage[0];
-            const topCropStr = topCrop
-              ? `${topCrop.landiqName} (${formatNumberWithCommas(Math.round(topCrop.acres))} ac)`
-              : 'N/A';
+            const escapeHtml = (value) =>
+              String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            const escapedName = escapeHtml(name);
             const salesRow = aggregates.totalCropSales != null
               ? `<tr style="border-top:1px solid #e5e7eb"><td>Reported crop sales</td><td style="text-align:right;padding-left:12px">$${formatNumberWithCommas(Math.round(aggregates.totalCropSales))}</td></tr>`
               : '';
+
+            // Per-crop breakdown of the constituents contributing to Total Crop
+            // Production. Top 3 stay visible to keep the popup compact; the full
+            // list lives behind a collapsible <details> so many-crop counties do
+            // not render a very tall popup.
+            const breakdown = aggregates.cropProductionBreakdown || [];
+            const breakdownRow = (crop) =>
+              `<tr><td style="padding-right:8px">${escapeHtml(crop.landiqName)}</td><td style="text-align:right">${formatNumberWithCommas(Math.round(crop.production))} tons</td></tr>`;
+            const topBreakdownRows = breakdown.slice(0, 3).map(breakdownRow).join('');
+            const restBreakdownRows = breakdown.slice(3).map(breakdownRow).join('');
+            const breakdownSection = breakdown.length === 0
+              ? ''
+              : `
+                <div style="margin-top:8px;border-top:1px solid #e5e7eb;padding-top:6px">
+                  <div style="font-weight:600;font-size:12px;margin-bottom:2px">Top crops by production</div>
+                  <table style="width:100%;border-collapse:collapse">${topBreakdownRows}</table>
+                  ${breakdown.length > 3 ? `
+                  <details style="margin-top:4px">
+                    <summary style="cursor:pointer;color:#2563eb;font-size:12px;user-select:none">Show all ${breakdown.length} crops</summary>
+                    <table style="width:100%;border-collapse:collapse;margin-top:4px">${restBreakdownRows}</table>
+                  </details>` : ''}
+                </div>`;
+
             popup.setHTML(`
-              <div class="county-popup" style="font-size:13px;line-height:1.6">
+              <div class="county-popup" style="font-size:13px;line-height:1.6;max-height:60vh;overflow-y:auto">
                 <strong style="font-size:14px">${escapedName} County</strong>
                 <table style="width:100%;margin-top:6px;border-collapse:collapse">
                   <tr><td>Total Crop Acreage</td><td style="text-align:right;padding-left:12px">${formatNumberWithCommas(Math.round(aggregates.totalCropAcreage))} ac</td></tr>
-                  <tr><td>Total Production</td><td style="text-align:right;padding-left:12px">${formatNumberWithCommas(Math.round(aggregates.totalCropProduction))} tons</td></tr>
-                  <tr><td>Collectable Residue</td><td style="text-align:right;padding-left:12px">${formatNumberWithCommas(Math.round(aggregates.totalResidueTons))} dry tons</td></tr>
-                  <tr><td>Avg Cellulose</td><td style="text-align:right;padding-left:12px">${avgCelluloseStr}</td></tr>
+                  <tr><td>Total Crop Production</td><td style="text-align:right;padding-left:12px">${formatNumberWithCommas(Math.round(aggregates.totalCropProduction))} tons</td></tr>
                   <tr style="border-top:1px solid #e5e7eb"><td>Feedstock types</td><td style="text-align:right;padding-left:12px">${aggregates.cropsCounted} crops</td></tr>
-                  <tr><td>Top crop</td><td style="text-align:right;padding-left:12px">${topCropStr}</td></tr>
                   ${salesRow}
                 </table>
+                ${breakdownSection}
                 <p style="margin-top:6px;font-size:11px;color:#6b7280">Source: 2022 USDA Census</p>
               </div>
             `);

--- a/src/lib/county-analysis.ts
+++ b/src/lib/county-analysis.ts
@@ -338,6 +338,12 @@ export interface CountyAggregates {
   cropsCounted: number;
   /** Top crops sorted by acreage descending (up to 3). */
   topCropsByAcreage: Array<{ landiqName: string; acres: number }>;
+  /**
+   * Full per-crop breakdown of the constituents contributing to Total Crop
+   * Production, sorted by production descending. Only crops with production > 0
+   * are included. Not capped, so the popup can render the complete list.
+   */
+  cropProductionBreakdown: Array<{ landiqName: string; production: number; acres: number }>;
   /** Sum of per-crop sales values where reported. null if no crop reported sales. */
   totalCropSales: number | null;
 }
@@ -360,6 +366,7 @@ export function computeCountyAggregates(
   let weightedCelluloseSum = 0;
   let celluloseWeightTotal = 0;
   const topCropsArr: Array<{ landiqName: string; acres: number }> = [];
+  const productionBreakdown: Array<{ landiqName: string; production: number; acres: number }> = [];
   let salesSum = 0;
   let hasSalesData = false;
 
@@ -374,6 +381,10 @@ export function computeCountyAggregates(
 
     if (acres > 0) {
       topCropsArr.push({ landiqName: stat.landiqName, acres });
+    }
+
+    if (production > 0) {
+      productionBreakdown.push({ landiqName: stat.landiqName, production, acres });
     }
 
     const salesMetric = getCountyMetricSales(stat);
@@ -398,6 +409,7 @@ export function computeCountyAggregates(
     : NaN;
 
   topCropsArr.sort((a, b) => b.acres - a.acres);
+  productionBreakdown.sort((a, b) => b.production - a.production);
 
   return {
     totalCropAcreage,
@@ -406,6 +418,7 @@ export function computeCountyAggregates(
     avgCelluloseContent,
     cropsCounted: stats.length,
     topCropsByAcreage: topCropsArr.slice(0, 3),
+    cropProductionBreakdown: productionBreakdown,
     totalCropSales: hasSalesData ? salesSum : null,
   };
 }

--- a/tests/county-analysis.test.ts
+++ b/tests/county-analysis.test.ts
@@ -390,6 +390,59 @@ test('computeCountyAggregates computes topCropsByAcreage sorted desc and capped 
   assert.equal(result.topCropsByAcreage[2].landiqName, 'Wheat');
 });
 
+// ---------------------------------------------------------------------------
+// computeCountyAggregates — cropProductionBreakdown (issue #97)
+// ---------------------------------------------------------------------------
+
+test('computeCountyAggregates returns full per-crop production breakdown sorted by production desc (not capped)', () => {
+  const stats: CountyCropStat[] = [
+    { ...cornStat, landiqName: 'Corn' },   // production 50000
+    { ...wheatStat, landiqName: 'Wheat' }, // production 20000
+    {
+      landiqName: 'Rice',
+      resource: 'rice straw',
+      source: 'census',
+      parameters: [
+        { parameter: 'area harvested', value: 9000, unit: 'acres', source: 'census' },
+        { parameter: 'production', value: 90000, unit: 'tons', source: 'census' },
+      ],
+    },
+    {
+      landiqName: 'Barley',
+      resource: 'barley straw',
+      source: 'census',
+      parameters: [
+        { parameter: 'area harvested', value: 3000, unit: 'acres', source: 'census' },
+        { parameter: 'production', value: 5000, unit: 'tons', source: 'census' },
+      ],
+    },
+  ];
+  const result = computeCountyAggregates(stats, {}, {});
+  // Full list of all 4 production-bearing crops (not sliced to 3)
+  assert.equal(result.cropProductionBreakdown.length, 4);
+  assert.deepEqual(
+    result.cropProductionBreakdown.map(c => c.landiqName),
+    ['Rice', 'Corn', 'Wheat', 'Barley']
+  );
+  assert.equal(result.cropProductionBreakdown[0].production, 90000);
+  assert.equal(result.cropProductionBreakdown[0].acres, 9000);
+  // breakdown productions sum to totalCropProduction
+  const sum = result.cropProductionBreakdown.reduce((acc, c) => acc + c.production, 0);
+  assert.equal(sum, result.totalCropProduction);
+});
+
+test('computeCountyAggregates cropProductionBreakdown excludes crops with zero production', () => {
+  const acresOnly: CountyCropStat = {
+    landiqName: 'Pasture',
+    resource: 'pasture',
+    source: 'census',
+    parameters: [{ parameter: 'area harvested', value: 4000, unit: 'acres', source: 'census' }],
+  };
+  const result = computeCountyAggregates([cornStat, acresOnly], {}, {});
+  assert.equal(result.cropProductionBreakdown.length, 1);
+  assert.equal(result.cropProductionBreakdown[0].landiqName, 'Corn');
+});
+
 test('computeCountyAggregates sums sales when present and returns null when none', () => {
   const withSales: CountyCropStat = {
     landiqName: 'Almonds',


### PR DESCRIPTION
Closes #97 (closed explicitly at staging-green per project rule).

## Summary
Reframes the county layer surface as **USDA primary-crop totals only**, per the 2026-06-19 planning decision. Derived residue numbers (sparse, double-counted across county lines) are dropped from the county surface and stay on the Crop Residues (LandIQ) layer.

## Changes
- **`Map.js` county popup**
  - Remove `Collectable Residue` and `Avg Cellulose` rows (derived values).
  - Rename `Total Production` to **`Total Crop Production`**.
  - Replace the single `Top crop` row with a **per-crop production breakdown**: top 3 constituents stay visible (compact), the full list lives behind a native `<details>` "Show all N crops" toggle.
  - Add `max-height:60vh; overflow-y:auto` so an expanded popup scrolls instead of overflowing.
- **`LayerControls.tsx`**
  - Relabel `County Level Stats` to **`USDA County Crop Totals`**.
  - Tooltip clarifies the crop-vs-residue source distinction from the Crop Residues (LandIQ) layer.
- **`county-analysis.ts`**
  - Add `cropProductionBreakdown` to `CountyAggregates`: full per-crop list sorted by production desc, zero-production crops excluded.

## Tests
- New unit tests for `cropProductionBreakdown` ordering, full-list (uncapped) behavior, and zero-production filtering.
- Full suite: 126 passing. `tsc --noEmit` clean. `next build` succeeds.

## Acceptance criteria
- [x] County popup shows no derived residue or cellulose values.
- [x] Sidebar label reads "USDA County Crop Totals", distinct in source from "Crop Residues".
- [x] Popup row reads "Total Crop Production".
- [x] Popup shows only top few crop constituents by default (compact).
- [x] Collapsible section expands to the full per-crop breakdown and collapses again.
- [x] Expanded popup does not overflow (internal scroll).
- [x] Siting point layer switch unaffected (no logic touched there).

Drift check: no drift (plan authored same day; all referenced files/lines verified).