### PR TITLE
fix(map): correct food-processor popup labels (#99)

### DIFF
--- a/src/lib/labelMappings.js
+++ b/src/lib/labelMappings.js
@@ -168,14 +168,19 @@ export const FOOD_PROCESSORS_LABELS = {
   'Address': 'Address',
   'City': 'City',
   'County': 'County',
+  'Zip_Code': 'ZIP Code',
+  'State': 'State',
   'ExcessFo_1': 'Excess Food - High Estimate (Tons/Year)',
   'ExcessFood': 'Excess Food - Low Estimate (Tons/Year)',
-  'NAICS_Co_1': 'NAICS Description',
-  'NAICS_Code': 'NAICS Code',
+  // NOTE: in the EPA tileset the column contents are swapped relative to their
+  // names - `NAICS_Code` holds the human-readable industry description (e.g.
+  // "Distilleries") and `NAICS_Co_1` holds the numeric NAICS code (e.g. "312140").
+  // Labels are intentionally matched to the actual VALUES so popups read correctly.
+  'NAICS_Code': 'NAICS Description',
+  'NAICS_Co_1': 'NAICS Code',
   'Name': 'Name',
   'OBJECTID': 'Object ID',
   'Phone1': 'Phone',
-  'State': 'State',
   'UniqueID': 'Unique ID',
   'Website': 'Website',
   'lat': 'Latitude',
@@ -331,6 +336,25 @@ export const CARB_FOOD_PROCESSORS_LABELS = {
   'longitude': 'Longitude',
 };
 
+export const TOMATO_PROCESSORS_LABELS = {
+  'Name': 'Name',
+  'Address': 'Address',
+  'City': 'City',
+  'County': 'County',
+  'Green': 'Green',
+  'Mold': 'Mold',
+  'Peels only': 'Peels Only',
+  'Pomace': 'Pomace',
+  'Pomace (peels)': 'Pomace (peels)',
+  'Pomace (seeds)': 'Pomace (seeds)',
+  'Seeds': 'Seeds',
+  'Vines': 'Vines',
+  'Processing capacity for tomato paste (tons/hr)': 'Processing Capacity for Tomato Paste (tons/hr)',
+  'Processing capacity of peeled/chopped (tons/hr)': 'Processing Capacity of Peeled/Chopped (tons/hr)',
+  'latitude': 'Latitude',
+  'longitude': 'Longitude',
+};
+
 export const layerLabelMappings = {
   'renewable-diesel': RENEWABLE_DIESEL_PLANTS_LABELS,
   'saf-plants': SUSTAINABLE_AVIATION_FUEL_PLANTS_LABELS,
@@ -343,6 +367,7 @@ export const layerLabelMappings = {
   'landfill-lfg': LANDFILLS_LABELS,
   'wastewater-treatment': WASTEWATER_TREATMENT_PLANTS_LABELS,
   'food-processors': FOOD_PROCESSORS_LABELS,
+  'tomato-processors': TOMATO_PROCESSORS_LABELS,
   'carb-food-processors': CARB_FOOD_PROCESSORS_LABELS,
   'food-retailers': FOOD_RETAILERS_LABELS,
   'power-plants': POWER_PLANTS_LABELS,


### PR DESCRIPTION
Closes #99.

## Summary
P0 demo-critical: food-processor popups. Diagnosed end-to-end on **production** (calbioscape.org) with the browser, inspecting the live Mapbox sources.

### What was actually happening
- **CARB** popups **already render correctly** on production (Name, Address, City, County, ZIP, State, Primary Agricultural Product, Byproducts, Air District, Data Source, Lat/Long). The literal headline bug did not reproduce — the `carb-food-processors` key path resolves and property keys match the mapping.
- **Tomato** processors had **no entry** in `layerLabelMappings` (the issue's lead hypothesis). The popup still rendered via the hardcoded tomato branch, but field labels fell back to generated title-case. Added an explicit `TOMATO_PROCESSORS_LABELS` so every food-processor layer id resolves to a mapping.
- **EPA "Other Processors"** popups rendered with **swapped NAICS labels**: the tileset stores the *description* in `NAICS_Code` (e.g. "Distilleries") and the *numeric code* in `NAICS_Co_1` (e.g. "312140"), so the popup showed "NAICS Code: Distilleries" / "NAICS Description: 312140". Verified across 10 features. Labels are now matched to the actual values, and `Zip_Code` is surfaced as ZIP Code.

### Changes
- `src/lib/labelMappings.js`
  - Fix `FOOD_PROCESSORS_LABELS` NAICS label swap; add `Zip_Code`.
  - Add `TOMATO_PROCESSORS_LABELS`; register `tomato-processors` in `layerLabelMappings`.

## Acceptance criteria
- [x] CARB processor popup opens with human-readable labeled fields — verified on prod.
- [ ] Tomato + EPA popups render with proper labels (no `undefined`) — to verify on staging/prod after deploy.

## Test plan
1. Deploy to staging; enable Food Processing Facilities -> Tomato / EPA / CARB.
2. Click a point of each type; confirm labeled popups, correct NAICS, no `undefined`.
3. Ship to prod; re-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
