### PR TITLE
feat(map): disaggregate CARB food processors by primary_ag_product (#98)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/county-analysis';
 import type { SelectedCountyFeedstockStats } from '@/lib/county-analysis';
 import { applyLayerMutualExclusivity } from '@/lib/layer-utils';
+import { CARB_PRODUCT_KEYS } from '@/lib/carb-product-categories';
 import CountyFeedstockPanel from '@/components/CountyFeedstockPanel';
 // Removed useSWRInfinite import
 const Map = dynamic(() => import('@/components/Map'), { ssr: false });
@@ -44,7 +45,9 @@ export default function Home() {
     districtEnergySystems: false,
     foodProcessors: false,
     tomatoProcessors: false,
-    carbFoodProcessors: false,
+    // CARB food processors are disaggregated by primary_ag_product (issue #98):
+    // one visibility key per product category, all off by default.
+    ...Object.fromEntries(CARB_PRODUCT_KEYS.map((k) => [k, false])),
     foodRetailers: false,
     powerPlants: false,
     foodBanks: false,
@@ -100,7 +103,7 @@ export default function Home() {
            layerVisibility.districtEnergySystems ||
            layerVisibility.foodProcessors ||
            layerVisibility.tomatoProcessors ||
-           layerVisibility.carbFoodProcessors ||
+           CARB_PRODUCT_KEYS.some((k) => layerVisibility[k]) ||
            layerVisibility.foodRetailers ||
            layerVisibility.powerPlants ||
            layerVisibility.foodBanks ||
@@ -121,7 +124,7 @@ export default function Home() {
     layerVisibility.districtEnergySystems,
     layerVisibility.foodProcessors,
     layerVisibility.tomatoProcessors,
-    layerVisibility.carbFoodProcessors,
+    ...CARB_PRODUCT_KEYS.map((k) => layerVisibility[k]),
     layerVisibility.foodRetailers,
     layerVisibility.powerPlants,
     layerVisibility.foodBanks,
@@ -207,7 +210,7 @@ export default function Home() {
       districtEnergySystems: isVisible,
       foodProcessors: isVisible,
       tomatoProcessors: isVisible,
-      carbFoodProcessors: isVisible,
+      ...Object.fromEntries(CARB_PRODUCT_KEYS.map((k) => [k, isVisible])),
       foodRetailers: isVisible,
       powerPlants: isVisible,
       foodBanks: isVisible,

--- a/src/components/LayerControls.tsx
+++ b/src/components/LayerControls.tsx
@@ -35,6 +35,7 @@ import {
   isCompositionFiltersActive,
 } from '@/lib/composition-filters';
 import { applyLayerMutualExclusivity, MUTUALLY_EXCLUSIVE_LAYERS } from '@/lib/layer-utils';
+import { CARB_PRODUCT_CATEGORIES, CARB_PRODUCT_KEYS } from '@/lib/carb-product-categories';
 
 // Pre-built lookup: layerId -> [partnerId, ...] for O(1) partner resolution in directLayerToggle
 const MUTUALLY_EXCLUSIVE_PAIRS: Record<string, string[]> = {};
@@ -605,7 +606,8 @@ const LayerControls: React.FC<LayerControlsProps> = ({
     districtEnergySystems: 'district-energy-systems-layer',
     foodProcessors: 'food-processors-layer',
     tomatoProcessors: 'tomato-processors-layer',
-    carbFoodProcessors: 'carb-food-processors-layer',
+    // CARB food processors disaggregated by primary_ag_product (issue #98)
+    ...Object.fromEntries(CARB_PRODUCT_CATEGORIES.map((c) => [c.key, c.mapboxLayerId])),
     foodRetailers: 'food-retailers-layer',
     powerPlants: 'power-plants-layer',
     foodBanks: 'food-banks-layer',
@@ -810,7 +812,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                         const infrastructureLayers = [
                           'anaerobicDigester', 'biodieselPlants', 'biorefineries', 'safPlants',
                           'renewableDiesel', 'mrf', 'cementPlants', 'landfillLfg',
-                          'wastewaterTreatment', 'wasteToEnergy', 'combustionPlants', 'districtEnergySystems', 'foodProcessors', 'tomatoProcessors', 'carbFoodProcessors', 'foodRetailers',
+                          'wastewaterTreatment', 'wasteToEnergy', 'combustionPlants', 'districtEnergySystems', 'foodProcessors', 'tomatoProcessors', ...CARB_PRODUCT_KEYS, 'foodRetailers',
                           'powerPlants', 'foodBanks', 'farmersMarkets'
                         ];
 
@@ -1213,9 +1215,9 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                           <Checkbox
                             id="foodProcessorsMaster"
                             checked={
-                              (localLayerVisibility?.foodProcessors && localLayerVisibility?.tomatoProcessors && localLayerVisibility?.carbFoodProcessors)
+                              (localLayerVisibility?.foodProcessors && localLayerVisibility?.tomatoProcessors && CARB_PRODUCT_KEYS.every((k) => localLayerVisibility?.[k]))
                                 ? true
-                                : (localLayerVisibility?.foodProcessors || localLayerVisibility?.tomatoProcessors || localLayerVisibility?.carbFoodProcessors)
+                                : (localLayerVisibility?.foodProcessors || localLayerVisibility?.tomatoProcessors || CARB_PRODUCT_KEYS.some((k) => localLayerVisibility?.[k]))
                                   ? 'indeterminate'
                                   : false
                             }
@@ -1223,7 +1225,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                               const isChecked = checked === true;
                               directLayerToggle('foodProcessors', isChecked, true);
                               directLayerToggle('tomatoProcessors', isChecked, true);
-                              directLayerToggle('carbFoodProcessors', isChecked, true);
+                              CARB_PRODUCT_KEYS.forEach((k) => directLayerToggle(k, isChecked, true));
                             }}
                           />
                           <Label htmlFor="foodProcessorsMaster" className="flex items-center text-xs font-medium">
@@ -1287,28 +1289,31 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                             </Label>
                           </div>
 
-                          {/* CARB Food Processors Layer Toggle - Subtype */}
-                          <div className="flex items-center space-x-2 pl-12">
-                            <Checkbox
-                              id="carbFoodProcessorsLayer"
-                              checked={localLayerVisibility?.carbFoodProcessors ?? false}
-                              onCheckedChange={(checked: boolean | 'indeterminate') => directLayerToggle('carbFoodProcessors', !!checked)}
-                            />
-                            <Label htmlFor="carbFoodProcessorsLayer" className="flex items-center text-xs">
-                              <span
-                                style={{
-                                  display: 'inline-block',
-                                  width: '10px',
-                                  height: '10px',
-                                  backgroundColor: '#14B8A6',
-                                  borderRadius: '50%',
-                                  marginRight: '2px',
-                                  flexShrink: 0,
-                                }}
-                              ></span>
-                              Other Processors (CARB)
-                            </Label>
-                          </div>
+                          {/* CARB Food Processors - disaggregated by primary_ag_product (issue #98).
+                              One independently-toggleable, color-coded legend entry per product. */}
+                          {CARB_PRODUCT_CATEGORIES.map((category) => (
+                            <div key={category.key} className="flex items-center space-x-2 pl-12">
+                              <Checkbox
+                                id={`${category.key}Layer`}
+                                checked={localLayerVisibility?.[category.key] ?? false}
+                                onCheckedChange={(checked: boolean | 'indeterminate') => directLayerToggle(category.key, !!checked)}
+                              />
+                              <Label htmlFor={`${category.key}Layer`} className="flex items-center text-xs">
+                                <span
+                                  style={{
+                                    display: 'inline-block',
+                                    width: '10px',
+                                    height: '10px',
+                                    backgroundColor: category.color,
+                                    borderRadius: '50%',
+                                    marginRight: '2px',
+                                    flexShrink: 0,
+                                  }}
+                                ></span>
+                                {category.label} (CARB)
+                              </Label>
+                            </div>
+                          ))}
                         </div>
                       )}
                     </div>

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -10,6 +10,7 @@ import SitingInventory from './SitingInventory'; // Import the new component
 import { INFRASTRUCTURE_LAYERS, getCropResidueFactors } from '@/lib/constants';
 import { TILESET_REGISTRY } from '@/lib/tileset-registry'; // Import centralized tileset registry
 import { layerLabelMappings } from '@/lib/labelMappings';
+import { CARB_PRODUCT_CATEGORIES, CARB_POPUP_LABEL_KEY, isCarbProductLayerId } from '@/lib/carb-product-categories';
 import { getAvailability, getAnalysisByResource, getCensusByCrop } from '@/lib/api';
 import { getCountyGeoid } from '@/lib/county-lookup';
 import { getApiResource, getUsdaCropName, STATE_GEOID } from '@/lib/resource-mapping';
@@ -397,7 +398,7 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
 
 
   // Add interactivity (click and hover) to a layer
-  const addLayerInteractivity = useCallback((layerId, popupTitle) => {
+  const addLayerInteractivity = useCallback((layerId, popupTitle, labelKey) => {
     if (!map.current) return;
 
     map.current.on('click', layerId, (e) => {
@@ -407,8 +408,10 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
       }
 
       if (e.features && e.features.length > 0) {
-        const layerIdWithoutSuffix = layerId.replace(/-layer$/, '');
-        createPopupForFeature(e.features[0], e.lngLat, popupTitle, layerIdWithoutSuffix);
+        // labelKey lets disaggregated layers (e.g. CARB product sub-layers) share
+        // one canonical label-mapping/popup key; defaults to the bare layer id.
+        const popupKey = labelKey || layerId.replace(/-layer$/, '');
+        createPopupForFeature(e.features[0], e.lngLat, popupTitle, popupKey);
       }
     });
 
@@ -2457,30 +2460,35 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
           console.error("Failed to add tomato processors layer:", error);
         }
 
-        // Add CARB food processors layer
-        try {
-          map.current.addLayer({
-            id: 'carb-food-processors-layer',
-            type: 'circle',
-            source: 'carb-food-processors-source',
-            'source-layer': TILESET_REGISTRY.carbFoodProcessors.sourceLayer,
-            minzoom: 0,
-            maxzoom: 22,
-            paint: {
-              'circle-color': '#14B8A6',
-              'circle-radius': 6,
-              'circle-opacity': 0.8,
-              'circle-stroke-color': '#FFFFFF',
-              'circle-stroke-width': 1
-            },
-            layout: {
-              'visibility': layerVisibility?.carbFoodProcessors ? 'visible' : 'none'
-            }
-          });
-          console.log("Added CARB food processors layer");
-        } catch (error) {
-          console.error("Failed to add CARB food processors layer:", error);
-        }
+        // Add CARB food processors layers, disaggregated by primary_ag_product
+        // (issue #98). One filtered circle layer per product so each legend entry
+        // toggles independently and carries a distinct color.
+        CARB_PRODUCT_CATEGORIES.forEach((category) => {
+          try {
+            map.current.addLayer({
+              id: category.mapboxLayerId,
+              type: 'circle',
+              source: 'carb-food-processors-source',
+              'source-layer': TILESET_REGISTRY.carbFoodProcessors.sourceLayer,
+              minzoom: 0,
+              maxzoom: 22,
+              filter: ['==', ['get', 'primary_ag_product'], category.product],
+              paint: {
+                'circle-color': category.color,
+                'circle-radius': 6,
+                'circle-opacity': 0.8,
+                'circle-stroke-color': '#FFFFFF',
+                'circle-stroke-width': 1
+              },
+              layout: {
+                'visibility': layerVisibility?.[category.key] ? 'visible' : 'none'
+              }
+            });
+            console.log(`Added CARB food processors layer for ${category.product}`);
+          } catch (error) {
+            console.error(`Failed to add CARB food processors layer for ${category.product}:`, error);
+          }
+        });
 
         // Add food retailers layer
         try {
@@ -2912,7 +2920,6 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
     'district-energy-systems-layer': 'District Energy System Details',
     'food-processors-layer': 'Food Processor Details',
     'tomato-processors-layer': 'Tomato Processing Facility Details',
-    'carb-food-processors-layer': 'Food Processor (CARB) Details',
     'food-retailers-layer': 'Food Retailer Details',
     'power-plants-layer': 'Power Plant Details',
           'food-banks-layer': 'Food Bank Details',
@@ -2924,6 +2931,14 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             addLayerInteractivity(layerId, popupTitle);
           }
         }
+
+        // CARB product sub-layers (issue #98): each filtered layer is interactive
+        // and shares the canonical CARB label mapping + popup title.
+        CARB_PRODUCT_CATEGORIES.forEach((category) => {
+          if (map.current.getLayer(category.mapboxLayerId)) {
+            addLayerInteractivity(category.mapboxLayerId, 'Food Processor (CARB) Details', CARB_POPUP_LABEL_KEY);
+          }
+        });
 
       }); // Closing bracket for map.current.on('load', ...)
 
@@ -3111,12 +3126,16 @@ useEffect(() => {
     'district-energy-systems-layer': layerVisibility?.districtEnergySystems,
     'food-processors-layer': layerVisibility?.foodProcessors,
     'tomato-processors-layer': layerVisibility?.tomatoProcessors,
-    'carb-food-processors-layer': layerVisibility?.carbFoodProcessors,
     'food-retailers-layer': layerVisibility?.foodRetailers,
     'power-plants-layer': layerVisibility?.powerPlants,
     'food-banks-layer': layerVisibility?.foodBanks,
     'farmers-markets-layer': layerVisibility?.farmersMarkets,
   };
+
+  // CARB product sub-layers (issue #98): one visibility key per primary_ag_product.
+  CARB_PRODUCT_CATEGORIES.forEach((category) => {
+    layerMapping[category.mapboxLayerId] = layerVisibility?.[category.key];
+  });
 
   Object.entries(layerMapping).forEach(([layerId, isVisible]) => {
     if (map.current.getLayer(layerId)) {
@@ -3125,8 +3144,10 @@ useEffect(() => {
         map.current.setLayoutProperty(layerId, 'visibility', visibility);
       }
 
-      // If the layer is being hidden and a popup for it is open, close the popup
-      if (!isVisible && currentPopup.current && currentPopupLayer === layerId.replace(/-layer$/, '')) {
+      // If the layer is being hidden and a popup for it is open, close the popup.
+      // CARB sub-layers share one canonical popup key, so normalize before comparing.
+      const popupKey = isCarbProductLayerId(layerId) ? CARB_POPUP_LABEL_KEY : layerId.replace(/-layer$/, '');
+      if (!isVisible && currentPopup.current && currentPopupLayer === popupKey) {
         currentPopup.current.remove();
         currentPopup.current = null;
         setCurrentPopupLayer(null);

--- a/src/lib/carb-product-categories.ts
+++ b/src/lib/carb-product-categories.ts
@@ -1,0 +1,52 @@
+// Disaggregation of the CARB food-processor tileset by `primary_ag_product`.
+//
+// The CARB tileset (`sustainasoft.carb-food-processors-*`, source layer
+// `carb_food_processors`) is a single dataset that carries a `primary_ag_product`
+// property on every feature. Issue #98 asks for this single layer to be split
+// into individually-toggleable, color-coded legend entries keyed by that product.
+//
+// This module is the single source of truth for that split: Map.js builds one
+// filtered Mapbox circle layer per entry, LayerControls renders one legend
+// checkbox per entry, and page.tsx seeds one visibility key per entry. The
+// `product` value must match the tileset's `primary_ag_product` string exactly
+// (the build pipeline in carb-food-processors-build.ts trims but does not
+// otherwise transform it).
+
+export interface CarbProductCategory {
+  /** Logical visibility key used in layerVisibility state (e.g. 'carbWine'). */
+  key: string;
+  /** Exact `primary_ag_product` value in the tileset (the Mapbox filter value). */
+  product: string;
+  /** Human-readable legend label. */
+  label: string;
+  /** Distinct legend/marker color. */
+  color: string;
+  /** Mapbox layer id for this category's filtered circle layer. */
+  mapboxLayerId: string;
+}
+
+// Ordered most-common first (matches the source dataset distribution). Colors are
+// chosen to be visually distinct across the set.
+export const CARB_PRODUCT_CATEGORIES: CarbProductCategory[] = [
+  { key: 'carbWine', product: 'Wine', label: 'Wine', color: '#9333EA', mapboxLayerId: 'carb-food-processors-wine-layer' },
+  { key: 'carbAlmonds', product: 'Almonds', label: 'Almonds', color: '#F97316', mapboxLayerId: 'carb-food-processors-almonds-layer' },
+  { key: 'carbWalnut', product: 'Walnut', label: 'Walnut', color: '#7C2D12', mapboxLayerId: 'carb-food-processors-walnut-layer' },
+  { key: 'carbTomatoes', product: 'Tomatoes', label: 'Tomatoes', color: '#DC2626', mapboxLayerId: 'carb-food-processors-tomatoes-layer' },
+  { key: 'carbCotton', product: 'Cotton', label: 'Cotton', color: '#0EA5E9', mapboxLayerId: 'carb-food-processors-cotton-layer' },
+  { key: 'carbPistachio', product: 'Pistachio', label: 'Pistachio', color: '#16A34A', mapboxLayerId: 'carb-food-processors-pistachio-layer' },
+  { key: 'carbPotato', product: 'Potato', label: 'Potato', color: '#92400E', mapboxLayerId: 'carb-food-processors-potato-layer' },
+  { key: 'carbWheat', product: 'Wheat', label: 'Wheat', color: '#CA8A04', mapboxLayerId: 'carb-food-processors-wheat-layer' },
+  { key: 'carbCorn', product: 'Corn', label: 'Corn', color: '#FACC15', mapboxLayerId: 'carb-food-processors-corn-layer' },
+  { key: 'carbRice', product: 'Rice', label: 'Rice', color: '#0D9488', mapboxLayerId: 'carb-food-processors-rice-layer' },
+];
+
+/** Logical visibility keys for all CARB product categories. */
+export const CARB_PRODUCT_KEYS: string[] = CARB_PRODUCT_CATEGORIES.map((c) => c.key);
+
+/** Canonical label-mapping / popup key shared by every CARB sub-layer. */
+export const CARB_POPUP_LABEL_KEY = 'carb-food-processors';
+
+/** True if the Mapbox layer id belongs to a CARB product sub-layer. */
+export function isCarbProductLayerId(mapboxLayerId: string): boolean {
+  return mapboxLayerId.startsWith('carb-food-processors-') && mapboxLayerId.endsWith('-layer');
+}


### PR DESCRIPTION
Closes #98

## What
Splits the single CARB food-processor layer ("Other Processors (CARB)", teal) into one **individually-toggleable, color-coded legend entry per `primary_ag_product`**, grouped under the existing **Food Processing Facilities** control. Uses the existing CARB tileset/source — no new data.

The 10 product categories present in the CARB dataset: Wine, Almonds, Walnut, Tomatoes, Cotton, Pistachio, Potato, Wheat, Corn, Rice.

## How
- **New `src/lib/carb-product-categories.ts`** — single source of truth (logical key, exact `primary_ag_product` value, legend label, distinct color, Mapbox layer id).
- **Map.js** — builds one filtered circle layer per product (`['==', ['get','primary_ag_product'], product]`); each is interactive and shares the canonical CARB label mapping + "Food Processor (CARB) Details" popup title via a new `labelKey` param on `addLayerInteractivity`. Visibility effect + popup-close normalize via the shared key.
- **page.tsx** — one visibility key per product (all off by default); infrastructure master, show/hide-all, and the food-processors group master aggregate them.
- **LayerControls.tsx** — renders one checkbox per product with its distinct color swatch.

## Acceptance criteria
- [x] CARB processors render as multiple legend entries keyed by `primary_ag_product`
- [x] Each entry has a distinct color and toggles on/off independently
- [x] Entries sit under the "Food Processing Facilities" group; no other layers regress

## Verification
- `next build` passes (TypeScript + compile clean).
- Local: legend renders all 10 distinct CARB entries with independent checkboxes under Food Processing Facilities; toggling resolves the correct per-product Mapbox layer id. (Point rendering / popups verified on staging where the Mapbox token is unrestricted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)