### PR TITLE
feat(map): reorder food-processor legend, drop (CARB)/(EPA) attributions

### DIFF
--- a/src/components/LayerControls.tsx
+++ b/src/components/LayerControls.tsx
@@ -1266,29 +1266,6 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                             </Label>
                           </div>
 
-                          {/* Other Food Processors Layer Toggle - Subtype */}
-                          <div className="flex items-center space-x-2 pl-12">
-                             <Checkbox
-                              id="foodProcessorsLayer"
-                              checked={localLayerVisibility?.foodProcessors ?? false}
-                              onCheckedChange={(checked: boolean | 'indeterminate') => directLayerToggle('foodProcessors', !!checked)}
-                            />
-                            <Label htmlFor="foodProcessorsLayer" className="flex items-center text-xs">
-                              <span
-                                style={{
-                                  display: 'inline-block',
-                                  width: '10px',
-                                  height: '10px',
-                                  backgroundColor: '#FFD700', /* Gold color for Food Processors */
-                                  borderRadius: '50%',
-                                  marginRight: '2px',
-                                  flexShrink: 0,
-                                }}
-                              ></span>
-                              Other Processors (EPA)
-                            </Label>
-                          </div>
-
                           {/* CARB Food Processors - disaggregated by primary_ag_product (issue #98).
                               One independently-toggleable, color-coded legend entry per product. */}
                           {CARB_PRODUCT_CATEGORIES.map((category) => (
@@ -1310,10 +1287,34 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                                     flexShrink: 0,
                                   }}
                                 ></span>
-                                {category.label} (CARB)
+                                {category.label}
                               </Label>
                             </div>
                           ))}
+
+                          {/* Other Food Processors (EPA) Layer Toggle - listed last as the
+                              catch-all after the specific tomato + CARB product subtypes. */}
+                          <div className="flex items-center space-x-2 pl-12">
+                             <Checkbox
+                              id="foodProcessorsLayer"
+                              checked={localLayerVisibility?.foodProcessors ?? false}
+                              onCheckedChange={(checked: boolean | 'indeterminate') => directLayerToggle('foodProcessors', !!checked)}
+                            />
+                            <Label htmlFor="foodProcessorsLayer" className="flex items-center text-xs">
+                              <span
+                                style={{
+                                  display: 'inline-block',
+                                  width: '10px',
+                                  height: '10px',
+                                  backgroundColor: '#FFD700', /* Gold color for Food Processors */
+                                  borderRadius: '50%',
+                                  marginRight: '2px',
+                                  flexShrink: 0,
+                                }}
+                              ></span>
+                              Other Processors
+                            </Label>
+                          </div>
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
Follow-up UI tweak to the Food Processing Facilities legend.

## Changes
- **Reorder** the subtypes so "Other Processors" is last: **Tomato Processors → Wine, Almonds, Walnut, Tomatoes, Cotton, Pistachio, Potato, Wheat, Corn, Rice → Other Processors** (catch-all at the bottom, a more logical sequence after the specific tomato + CARB product subtypes).
- **Remove** the "(CARB)" and "(EPA)" source attributions from the legend labels for a cleaner read.

Presentation-only change in `LayerControls.tsx`; no layer/visibility/toggle behavior changes. `next build` passes (TypeScript + compile clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)