### PR TITLE
fix(map): keep CARB popups open + align food-processor subtype rows (#99)

### DIFF
--- a/src/components/LayerControls.tsx
+++ b/src/components/LayerControls.tsx
@@ -1244,7 +1244,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                       {!isFoodProcessorsCollapsed && (
                         <div className="space-y-1">
                           {/* Tomato Processors Layer Toggle - Subtype */}
-                          <div className="flex items-center space-x-2 pl-12">
+                          <div className="flex items-center space-x-2 pl-6">
                              <Checkbox
                               id="tomatoProcessorsLayer"
                               checked={localLayerVisibility?.tomatoProcessors ?? false}
@@ -1269,7 +1269,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                           {/* CARB Food Processors - disaggregated by primary_ag_product (issue #98).
                               One independently-toggleable, color-coded legend entry per product. */}
                           {CARB_PRODUCT_CATEGORIES.map((category) => (
-                            <div key={category.key} className="flex items-center space-x-2 pl-12">
+                            <div key={category.key} className="flex items-center space-x-2 pl-6">
                               <Checkbox
                                 id={`${category.key}Layer`}
                                 checked={localLayerVisibility?.[category.key] ?? false}
@@ -1294,7 +1294,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
 
                           {/* Other Food Processors (EPA) Layer Toggle - listed last as the
                               catch-all after the specific tomato + CARB product subtypes. */}
-                          <div className="flex items-center space-x-2 pl-12">
+                          <div className="flex items-center space-x-2 pl-6">
                              <Checkbox
                               id="foodProcessorsLayer"
                               checked={localLayerVisibility?.foodProcessors ?? false}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -3144,16 +3144,33 @@ useEffect(() => {
         map.current.setLayoutProperty(layerId, 'visibility', visibility);
       }
 
-      // If the layer is being hidden and a popup for it is open, close the popup.
-      // CARB sub-layers share one canonical popup key, so normalize before comparing.
-      const popupKey = isCarbProductLayerId(layerId) ? CARB_POPUP_LABEL_KEY : layerId.replace(/-layer$/, '');
-      if (!isVisible && currentPopup.current && currentPopupLayer === popupKey) {
-        currentPopup.current.remove();
-        currentPopup.current = null;
-        setCurrentPopupLayer(null);
+      // If a non-CARB layer is being hidden and its popup is open, close it.
+      // CARB sub-layers all share ONE canonical popup key, so a single hidden
+      // sibling must not close a popup that belongs to a still-visible CARB
+      // layer - their closure is handled collectively below.
+      if (!isCarbProductLayerId(layerId)) {
+        const popupKey = layerId.replace(/-layer$/, '');
+        if (!isVisible && currentPopup.current && currentPopupLayer === popupKey) {
+          currentPopup.current.remove();
+          currentPopup.current = null;
+          setCurrentPopupLayer(null);
+        }
       }
     }
   });
+
+  // Close an open CARB popup only when EVERY CARB sub-layer is hidden. Because all
+  // CARB product sub-layers share the canonical popup key, per-layer comparison in
+  // the loop above would let a hidden sibling close a popup that still belongs to a
+  // visible CARB layer (issue #98 regression: CARB popups opened then vanished).
+  if (currentPopup.current && currentPopupLayer === CARB_POPUP_LABEL_KEY) {
+    const anyCarbVisible = CARB_PRODUCT_CATEGORIES.some((category) => layerVisibility?.[category.key]);
+    if (!anyCarbVisible) {
+      currentPopup.current.remove();
+      currentPopup.current = null;
+      setCurrentPopupLayer(null);
+    }
+  }
 }, [mapLoaded, layerVisibility, currentPopupLayer]);
 
   // Define validateBufferState function before it's used in dependency arrays


### PR DESCRIPTION
Follow-up to #103 (issue #99 verification on production surfaced two more problems).

## 1. CARB popups open then instantly vanish (regression from #98)
All CARB product sub-layers share one canonical popup key (`CARB_POPUP_LABEL_KEY`). The visibility-sync effect closed an open popup whenever **any** layer with that key was hidden — so opening a Wine popup was instantly closed by its hidden siblings (Almonds, Walnut, …). Verified on prod: layer click handler fires with the right feature, popup is created, then the effect removes it (no console error).

**Fix:** non-CARB layers still close their popup per-layer; the shared CARB popup closes only when **every** CARB sub-layer is hidden.

## 2. Food-processor subtype indentation
Subtype rows were `pl-12` (inside a `pl-6` group container = 72px), far past the major layers' colored circles. Changed to `pl-6` so the subtype checkboxes align with the major layers' colored circles, matching other nested groups.

## Test plan (staging then prod)
1. Enable one CARB product (e.g. Wine); click a point → popup stays open with labeled fields.
2. Toggle other CARB products on/off → popup persists; disable all CARB → popup closes.
3. Tomato + EPA popups still work.
4. Visually confirm subtype checkbox alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)