### PR TITLE
Release: CARB popup fix + food-processor legend polish (#99)

### DIFF
--- a/src/components/LayerControls.tsx
+++ b/src/components/LayerControls.tsx
@@ -1266,29 +1266,6 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                             </Label>
                           </div>
 
-                          {/* Other Food Processors Layer Toggle - Subtype */}
-                          <div className="flex items-center space-x-2 pl-12">
-                             <Checkbox
-                              id="foodProcessorsLayer"
-                              checked={localLayerVisibility?.foodProcessors ?? false}
-                              onCheckedChange={(checked: boolean | 'indeterminate') => directLayerToggle('foodProcessors', !!checked)}
-                            />
-                            <Label htmlFor="foodProcessorsLayer" className="flex items-center text-xs">
-                              <span
-                                style={{
-                                  display: 'inline-block',
-                                  width: '10px',
-                                  height: '10px',
-                                  backgroundColor: '#FFD700', /* Gold color for Food Processors */
-                                  borderRadius: '50%',
-                                  marginRight: '2px',
-                                  flexShrink: 0,
-                                }}
-                              ></span>
-                              Other Processors (EPA)
-                            </Label>
-                          </div>
-
                           {/* CARB Food Processors - disaggregated by primary_ag_product (issue #98).
                               One independently-toggleable, color-coded legend entry per product. */}
                           {CARB_PRODUCT_CATEGORIES.map((category) => (
@@ -1310,10 +1287,34 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                                     flexShrink: 0,
                                   }}
                                 ></span>
-                                {category.label} (CARB)
+                                {category.label}
                               </Label>
                             </div>
                           ))}
+
+                          {/* Other Food Processors (EPA) Layer Toggle - listed last as the
+                              catch-all after the specific tomato + CARB product subtypes. */}
+                          <div className="flex items-center space-x-2 pl-12">
+                             <Checkbox
+                              id="foodProcessorsLayer"
+                              checked={localLayerVisibility?.foodProcessors ?? false}
+                              onCheckedChange={(checked: boolean | 'indeterminate') => directLayerToggle('foodProcessors', !!checked)}
+                            />
+                            <Label htmlFor="foodProcessorsLayer" className="flex items-center text-xs">
+                              <span
+                                style={{
+                                  display: 'inline-block',
+                                  width: '10px',
+                                  height: '10px',
+                                  backgroundColor: '#FFD700', /* Gold color for Food Processors */
+                                  borderRadius: '50%',
+                                  marginRight: '2px',
+                                  flexShrink: 0,
+                                }}
+                              ></span>
+                              Other Processors
+                            </Label>
+                          </div>
                         </div>
                       )}
                     </div>

--- a/src/components/LayerControls.tsx
+++ b/src/components/LayerControls.tsx
@@ -1244,7 +1244,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                       {!isFoodProcessorsCollapsed && (
                         <div className="space-y-1">
                           {/* Tomato Processors Layer Toggle - Subtype */}
-                          <div className="flex items-center space-x-2 pl-12">
+                          <div className="flex items-center space-x-2 pl-6">
                              <Checkbox
                               id="tomatoProcessorsLayer"
                               checked={localLayerVisibility?.tomatoProcessors ?? false}
@@ -1269,7 +1269,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                           {/* CARB Food Processors - disaggregated by primary_ag_product (issue #98).
                               One independently-toggleable, color-coded legend entry per product. */}
                           {CARB_PRODUCT_CATEGORIES.map((category) => (
-                            <div key={category.key} className="flex items-center space-x-2 pl-12">
+                            <div key={category.key} className="flex items-center space-x-2 pl-6">
                               <Checkbox
                                 id={`${category.key}Layer`}
                                 checked={localLayerVisibility?.[category.key] ?? false}
@@ -1294,7 +1294,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
 
                           {/* Other Food Processors (EPA) Layer Toggle - listed last as the
                               catch-all after the specific tomato + CARB product subtypes. */}
-                          <div className="flex items-center space-x-2 pl-12">
+                          <div className="flex items-center space-x-2 pl-6">
                              <Checkbox
                               id="foodProcessorsLayer"
                               checked={localLayerVisibility?.foodProcessors ?? false}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -3144,16 +3144,33 @@ useEffect(() => {
         map.current.setLayoutProperty(layerId, 'visibility', visibility);
       }
 
-      // If the layer is being hidden and a popup for it is open, close the popup.
-      // CARB sub-layers share one canonical popup key, so normalize before comparing.
-      const popupKey = isCarbProductLayerId(layerId) ? CARB_POPUP_LABEL_KEY : layerId.replace(/-layer$/, '');
-      if (!isVisible && currentPopup.current && currentPopupLayer === popupKey) {
-        currentPopup.current.remove();
-        currentPopup.current = null;
-        setCurrentPopupLayer(null);
+      // If a non-CARB layer is being hidden and its popup is open, close it.
+      // CARB sub-layers all share ONE canonical popup key, so a single hidden
+      // sibling must not close a popup that belongs to a still-visible CARB
+      // layer - their closure is handled collectively below.
+      if (!isCarbProductLayerId(layerId)) {
+        const popupKey = layerId.replace(/-layer$/, '');
+        if (!isVisible && currentPopup.current && currentPopupLayer === popupKey) {
+          currentPopup.current.remove();
+          currentPopup.current = null;
+          setCurrentPopupLayer(null);
+        }
       }
     }
   });
+
+  // Close an open CARB popup only when EVERY CARB sub-layer is hidden. Because all
+  // CARB product sub-layers share the canonical popup key, per-layer comparison in
+  // the loop above would let a hidden sibling close a popup that still belongs to a
+  // visible CARB layer (issue #98 regression: CARB popups opened then vanished).
+  if (currentPopup.current && currentPopupLayer === CARB_POPUP_LABEL_KEY) {
+    const anyCarbVisible = CARB_PRODUCT_CATEGORIES.some((category) => layerVisibility?.[category.key]);
+    if (!anyCarbVisible) {
+      currentPopup.current.remove();
+      currentPopup.current = null;
+      setCurrentPopupLayer(null);
+    }
+  }
 }, [mapLoaded, layerVisibility, currentPopupLayer]);
 
   // Define validateBufferState function before it's used in dependency arrays


### PR DESCRIPTION
Promotes staging to production for the demo.

Contents:
- **#107** (issue #99): keep CARB popups open (fix #98 regression where popups opened then vanished); align food-processor subtype indentation.
- **#106** (parallel, already on staging): reorder food-processor legend + drop source attributions.

Verified on staging.calbioscape.org: CARB (Wine) popup stays open with proper labels; Tomato + EPA popups correct; subtype checkboxes aligned with major-layer circles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)