### PR TITLE
fix(map): drop 'Processors' suffix from Tomato/Other legend entries

### DIFF
--- a/src/components/LayerControls.tsx
+++ b/src/components/LayerControls.tsx
@@ -1262,7 +1262,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                                   flexShrink: 0,
                                 }}
                               ></span>
-                              Tomato Processors
+                              Tomato
                             </Label>
                           </div>
 
@@ -1312,7 +1312,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                                   flexShrink: 0,
                                 }}
                               ></span>
-                              Other Processors
+                              Other
                             </Label>
                           </div>
                         </div>


### PR DESCRIPTION
## What

Removes the redundant "Processors" suffix from two entries in the **Food Processing Facilities** legend:

- \`Tomato Processors\` → \`Tomato\`
- \`Other Processors\` → \`Other\`

## Why

All other subtypes in this legend section (Wine, Almonds, Walnut, Tomatoes, Cotton, Pistachio, Potato, Wheat, Corn, Rice) are labeled by product alone. Tomato and Other were the only two carrying a "Processors" suffix, breaking the visual consistency of the list.

## Scope

Label text only in \`src/components/LayerControls.tsx\`. No layer keys, colors, toggles, or data behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)