### PR TITLE
Promote: drop 'Processors' suffix from Tomato/Other legend entries

### DIFF
--- a/src/components/LayerControls.tsx
+++ b/src/components/LayerControls.tsx
@@ -1262,7 +1262,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                                   flexShrink: 0,
                                 }}
                               ></span>
-                              Tomato Processors
+                              Tomato
                             </Label>
                           </div>
 
@@ -1312,7 +1312,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                                   flexShrink: 0,
                                 }}
                               ></span>
-                              Other Processors
+                              Other
                             </Label>
                           </div>
                         </div>


### PR DESCRIPTION
Promotes the only unreleased change on \`staging\` to production.

### Content delta (staging vs main)
- fix(map): drop "Processors" suffix from Tomato/Other legend entries (#109)

Renames \`Tomato Processors\` → \`Tomato\` and \`Other Processors\` → \`Other\` in the Food Processing Facilities legend for consistency with the other product-named subtypes. Label text only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)