### PR TITLE
fix(siting-inventory): align color swatches across collapsible/non-collapsible rows

### DIFF
--- a/src/components/SitingInventory.tsx
+++ b/src/components/SitingInventory.tsx
@@ -443,10 +443,12 @@ const SitingInventory: React.FC<SitingInventoryProps> = ({
                           >
                             <td className="py-2 px-2 whitespace-normal">
                               <div className="flex items-center gap-1.5">
-                                {hasComposition && (
+                                {hasComposition ? (
                                   <ChevronDown
                                     className={`h-3 w-3 text-gray-400 flex-shrink-0 transition-transform ${isExpanded ? 'rotate-0' : '-rotate-90'}`}
                                   />
+                                ) : (
+                                  <span className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
                                 )}
                                 <span
                                   className="inline-block h-3 w-3 rounded-sm flex-shrink-0"


### PR DESCRIPTION
## Summary
Non-collapsible crop-residue rows (those without composition data, so no chevron) now render an invisible `h-3 w-3` spacer where the chevron would be, so their circular color swatches align vertically with the collapsible (chevron) rows in the siting-mode crop residues inventory table.

## Why some rows lack chevrons
A row is collapsible only when `composition?.hasData === true` for its `apiResource`. Rows without composition data render no chevron and don't expand — that behavior is unchanged. This PR only fixes the horizontal alignment of the swatches.

## Test
- Trivial JSX change (ternary swaps the conditional chevron for a spacer placeholder).
- Visual alignment to be confirmed post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)