### PR TITLE
Promote: align crop-residue color swatches across collapsible/non-collapsible rows

### DIFF
--- a/src/components/SitingInventory.tsx
+++ b/src/components/SitingInventory.tsx
@@ -443,10 +443,12 @@ const SitingInventory: React.FC<SitingInventoryProps> = ({
                           >
                             <td className="py-2 px-2 whitespace-normal">
                               <div className="flex items-center gap-1.5">
-                                {hasComposition && (
+                                {hasComposition ? (
                                   <ChevronDown
                                     className={`h-3 w-3 text-gray-400 flex-shrink-0 transition-transform ${isExpanded ? 'rotate-0' : '-rotate-90'}`}
                                   />
+                                ) : (
+                                  <span className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
                                 )}
                                 <span
                                   className="inline-block h-3 w-3 rounded-sm flex-shrink-0"


### PR DESCRIPTION
## Promote staging → production

Single change in this promotion:
- **fix(siting-inventory):** non-collapsible crop-residue rows now render an invisible `h-3 w-3` spacer in place of the chevron, so their circular color swatches align vertically with the collapsible (chevron) rows in the siting-mode crop residues inventory table.

Staging Cloud Build is green (build `2993a9c3`, SUCCESS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)