### PR TITLE
perf(county): share county-stats cache + page-load prefetch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -856,7 +856,9 @@ All values on dry basis (moisture as-received). Grouped by crop category.
 
 | Export | Description |
 |---|---|
-| `fetchCountyFeedstockStats(geoid)` | Fetches both census and survey stats for each mapped resource at a county, merges parameter-level facts, and returns rows with displayable acres or production metrics. |
+| `fetchCountyFeedstockStats(geoid)` | Fetches both census and survey stats for each mapped resource at a county, merges parameter-level facts, and returns rows with displayable acres or production metrics. **Session-cached** (wraps `makePromiseCache`): a county is fetched once per session, so the map popup (via `getCountyAggregateStats`) and the county panel (via `page.tsx handleCountySelect`) share one fetch and repeat clicks hit memory with no refetch. Stale-within-session is intentional (DB is static during a session). |
+| `prefetchAllCountyStats(geoids)` | Idempotent, fire-and-forget page-load cache warmer: throttled sweep that pre-fills the `fetchCountyFeedstockStats` cache for every clickable county so the first click is instant. Kicked off on idle from `page.tsx` (`requestIdleCallback`/`setTimeout`) so it never blocks first paint. Cost ceiling scales ~2×N_resources×N_counties — the durable fix is a backend batch/all-counties endpoint + DB indexing (ca-biositing repo, out of scope here). |
+| `warmPromiseCache(keys, fetch, concurrency)` | Generic, testable warming primitive: throttled, swallows per-key failures. Used by `prefetchAllCountyStats`. |
 | `getCountyMetric(stat, metric)` | Selects the exact displayed acres or production metric. Production ignores `operations` unit rows such as `area in production`. |
 | `getDisplaySources(...metrics)` | Returns the unique census/survey sources used by the selected visible metrics. |
 | `CountyCropStat` | `{ landiqName, resource, parameters: CountyParameterStat[], source: 'census' \| 'survey' \| 'mixed' }` |

--- a/e2e/tests/county-layer.spec.ts
+++ b/e2e/tests/county-layer.spec.ts
@@ -68,3 +68,23 @@ test('county Mapbox layers become visible when the checkbox is enabled', async (
   );
   expect(countyLayerHidden).toBe('none');
 });
+
+// Regression test for issue #100: the page warms the county-stats cache on load
+// so the first county click is served from memory. We assert the browser fires
+// county USDA proxy requests for multiple counties WITHOUT any county click —
+// proving the idle prefetch sweep runs (and is not a single on-demand fetch).
+// Backend availability is irrelevant: we only assert the browser->proxy request
+// is issued, not its response.
+test('warms the county stats cache on page load without a click (issue #100)', async ({ page }) => {
+  const countyGeoids = new Set<string>();
+  page.on('request', req => {
+    const match = req.url().match(/\/api\/proxy\/.*\/usda\/.*\/geoid\/(\d{5})\//);
+    if (match) countyGeoids.add(match[1]);
+  });
+
+  await page.goto('/');
+
+  // Prefetch is idle-scheduled (requestIdleCallback / setTimeout fallback), so
+  // give it time to issue requests for more than one county.
+  await expect.poll(() => countyGeoids.size, { timeout: 25000 }).toBeGreaterThan(1);
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,8 +7,10 @@ import { batchFetchCompositionData, CompositionLookup, CompositionFilters, DEFAU
 import {
   fetchCountyFeedstockStats,
   getCountyPanelSelectionForResponse,
+  prefetchAllCountyStats,
 } from '@/lib/county-analysis';
 import type { SelectedCountyFeedstockStats } from '@/lib/county-analysis';
+import { getAllCountyGeoids } from '@/lib/county-lookup';
 import { applyLayerMutualExclusivity } from '@/lib/layer-utils';
 import { CARB_PRODUCT_KEYS } from '@/lib/carb-product-categories';
 import CountyFeedstockPanel from '@/components/CountyFeedstockPanel';
@@ -68,6 +70,25 @@ export default function Home() {
     batchFetchCompositionData()
       .then(setCompositionLookup)
       .catch(err => console.warn('[composition] Failed to fetch composition data:', err));
+  }, []);
+
+  // Warm the county stats cache for every clickable county so the first county
+  // click is served from memory. Scheduled on idle (after first paint) so it
+  // never competes with the initial render or the data loads above. The sweep
+  // is throttled and idempotent, and shares one cache with on-demand clicks.
+  useEffect(() => {
+    const geoids = Object.values(getAllCountyGeoids());
+    const kickoff = () => prefetchAllCountyStats(geoids);
+    type IdleWindow = Window & {
+      requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+    };
+    const idleWindow = window as IdleWindow;
+    if (typeof idleWindow.requestIdleCallback === 'function') {
+      idleWindow.requestIdleCallback(kickoff, { timeout: 3000 });
+      return;
+    }
+    const timeoutId = setTimeout(kickoff, 2000);
+    return () => clearTimeout(timeoutId);
   }, []);
 
   // Effect to dispatch resize event when panel collapses/expands

--- a/src/lib/county-analysis.ts
+++ b/src/lib/county-analysis.ts
@@ -272,7 +272,7 @@ const COUNTY_FETCH_CONCURRENCY = 5;
  * Merges census and survey data so missing metrics can fall through per parameter.
  * Returns only crops that have at least one data point.
  */
-export async function fetchCountyFeedstockStats(
+async function fetchCountyFeedstockStatsUncached(
   geoid: string
 ): Promise<CountyCropStat[]> {
   const authAwareFetch = { throwOnAuthError: true };
@@ -323,6 +323,69 @@ export async function fetchCountyFeedstockStats(
       r.status === 'fulfilled' && r.value !== null
     )
     .map(r => r.value);
+}
+
+/**
+ * Fetch county-level USDA stats, cached for the session.
+ *
+ * Both consumers route through this single cache:
+ *   - the map popup, via getCountyAggregateStats -> computeCountyAggregateStats
+ *   - the county feedstock panel (page.tsx handleCountySelect)
+ * so a county is fetched at most once per session and the two paths never
+ * duplicate the request on a single click. Re-clicking a county is served from
+ * memory with no network refetch. Rejected entries are evicted so a failed
+ * county retries on the next click.
+ *
+ * Acceptable-staleness model: the first fetch captures the backend DB state at
+ * that moment. The backend is not updated within a user session, so serving the
+ * session-cached snapshot for repeat clicks is intentional, not stale data.
+ */
+export const fetchCountyFeedstockStats = makePromiseCache(fetchCountyFeedstockStatsUncached);
+
+/**
+ * Idempotent, throttled, error-swallowing cache warmer. Pure with respect to its
+ * `fetch` argument so it can be unit-tested without the network. Each key is
+ * fetched at most once (the caller passes a cached fetcher); a key whose fetch
+ * rejects is swallowed here so one failure never aborts the sweep, and the
+ * underlying promise cache evicts it for a later retry.
+ */
+export async function warmPromiseCache<T>(
+  keys: string[],
+  fetch: (key: string) => Promise<T>,
+  concurrency: number
+): Promise<void> {
+  const tasks = keys.map(key => () => fetch(key).catch(() => undefined));
+  await throttledSettled(tasks, concurrency);
+}
+
+// Outer concurrency for the page-load county sweep. Kept below
+// COUNTY_FETCH_CONCURRENCY's effective fan-out because each county already
+// throttles its own per-resource fetches internally.
+const COUNTY_PREFETCH_CONCURRENCY = 3;
+let countyPrefetchStarted = false;
+
+/**
+ * Warm the session cache for every clickable county so the first popup/panel
+ * click is served from memory with no per-click round-trip.
+ *
+ * - Idempotent: only the first call does work (guarded by countyPrefetchStarted).
+ * - Non-blocking: fire-and-forget; callers kick this off on idle after first paint.
+ * - Deduped: routes through the same fetchCountyFeedstockStats cache as on-demand
+ *   clicks, so an in-flight prefetch and a user click never double-fetch a county.
+ * - Throttled: COUNTY_PREFETCH_CONCURRENCY caps the sweep; each county's own
+ *   fetch is itself throttled at COUNTY_FETCH_CONCURRENCY.
+ *
+ * Cost ceiling: each county issues ~2 requests per mapped resource (census +
+ * survey). Today only a few counties return data (backend ETL limit), so the
+ * sweep is cheap. When all 58 counties have data this is ~2 x N_resources x 58
+ * requests; the throttle keeps that from flooding the proxy. The durable fix is
+ * a backend batch / all-counties endpoint plus DB indexing on the bio-siting
+ * tables (tracked in the ca-biositing backend repo, out of scope here).
+ */
+export function prefetchAllCountyStats(geoids: string[]): void {
+  if (countyPrefetchStarted) return;
+  countyPrefetchStarted = true;
+  void warmPromiseCache(geoids, fetchCountyFeedstockStats, COUNTY_PREFETCH_CONCURRENCY);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/county-analysis.test.ts
+++ b/tests/county-analysis.test.ts
@@ -13,6 +13,9 @@ import {
   getDisplaySources,
   computeCountyAggregates,
   throttledSettled,
+  warmPromiseCache,
+  fetchCountyFeedstockStats,
+  makePromiseCache,
 } from '../src/lib/county-analysis';
 
 // ---------------------------------------------------------------------------
@@ -441,6 +444,66 @@ test('computeCountyAggregates cropProductionBreakdown excludes crops with zero p
   const result = computeCountyAggregates([cornStat, acresOnly], {}, {});
   assert.equal(result.cropProductionBreakdown.length, 1);
   assert.equal(result.cropProductionBreakdown[0].landiqName, 'Corn');
+});
+
+// ---------------------------------------------------------------------------
+// Issue #100: county popup latency — shared cache + page-load prefetch warming
+// ---------------------------------------------------------------------------
+
+test('fetchCountyFeedstockStats deduplicates concurrent calls for the same geoid (cached)', () => {
+  // Two synchronous calls for the same geoid must return the identical promise,
+  // proving the raw stats fetch is cache-wrapped and a re-click hits the cache
+  // rather than firing a second network request.
+  const first = fetchCountyFeedstockStats('06099');
+  const second = fetchCountyFeedstockStats('06099');
+  assert.equal(first, second, 'same geoid should share one cached promise');
+  // Swallow the network rejection in the test env (no proxy server running).
+  first.catch(() => {});
+  second.catch(() => {});
+});
+
+test('warmPromiseCache fetches every key exactly once', async () => {
+  const fetched: string[] = [];
+  await warmPromiseCache(
+    ['06001', '06003', '06005'],
+    async (key: string) => { fetched.push(key); return key; },
+    2
+  );
+  assert.deepEqual(fetched.sort(), ['06001', '06003', '06005']);
+});
+
+test('warmPromiseCache shares a cache with on-demand clicks (no duplicate fetches)', async () => {
+  // Models the real wiring: prefetch and clicks both go through one promise cache.
+  let factoryCalls = 0;
+  const cache = makePromiseCache(async (geoid: string) => {
+    factoryCalls++;
+    return geoid;
+  });
+  const geoids = ['06001', '06003', '06005'];
+
+  // Page-load prefetch warms every county.
+  await warmPromiseCache(geoids, cache, 2);
+  // Subsequent "clicks" on already-warmed counties must not refetch.
+  await Promise.all(geoids.map(g => cache(g)));
+
+  assert.equal(factoryCalls, geoids.length, 'each county fetched once across prefetch + clicks');
+});
+
+test('warmPromiseCache swallows per-key failures without aborting the sweep', async () => {
+  const succeeded: string[] = [];
+  await assert.doesNotReject(() =>
+    warmPromiseCache(
+      ['bad', '06001', '06003'],
+      async (key: string) => {
+        if (key === 'bad') throw new Error('boom');
+        succeeded.push(key);
+        return key;
+      },
+      2
+    )
+  );
+  // The failing key did not prevent the others from completing.
+  assert.deepEqual(succeeded.sort(), ['06001', '06003']);
 });
 
 test('computeCountyAggregates sums sales when present and returns null when none', () => {


### PR DESCRIPTION
## Summary

- Eliminates county-popup refetch latency: county USDA stats now flow through one session cache shared by the map popup and the county feedstock panel, so repeat clicks are served from memory with no network round-trip.
- Adds a page-load prefetch that warms every clickable county on idle (non-blocking to first paint), so the first click on a county is instant.

## Content Delta

- `src/lib/county-analysis.ts` — `fetchCountyFeedstockStats` is now session-cached (`makePromiseCache`); new `prefetchAllCountyStats` (idempotent, throttled, idle-scheduled warmer) and `warmPromiseCache` (testable primitive).
- `src/app/page.tsx` — kicks off the county prefetch on idle (`requestIdleCallback` / `setTimeout` fallback).
- `tests/county-analysis.test.ts` — +4 unit tests (cache dedup, shared-cache no-dup-fetch, per-key failure tolerance).
- `e2e/tests/county-layer.spec.ts` — +1 regression test (page warms multiple counties on load without a click).
- `AGENTS.md` — documents the new exports + caching/prefetch behavior.

## Ancestry Diagnostics

- Diagnostic commit count: 1 (`f5a86f5`, squash-merged PR #121).

## Test plan

- [ ] Click a county, then re-click it: second click renders instantly with no new `/geoid/` network request.
- [ ] On page load (before any click), county USDA requests fire automatically for multiple counties (cache warming).
- [ ] No regression in county panel / popup data accuracy (e.g. Stanislaus shows Rice, Wheat, Cotton, Tomatoes).

*Co-authored with Codex.*
