### PR TITLE
ci: bump actions/checkout + setup-node v4 → v5 (clear Node 20 deprecation)

### DIFF
--- a/.github/workflows/refresh-county-snapshot.yml
+++ b/.github/workflows/refresh-county-snapshot.yml
@@ -34,12 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout staging
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: staging
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
Bumps `actions/checkout` and `actions/setup-node` from `@v4` → `@v5` in the two active workflows (`security.yml`, `refresh-county-snapshot.yml`). v5 runs the actions on **Node 24**, clearing the Node 20 deprecation warning. The workflow steps still install the `.nvmrc`-pinned Node 20.20.0 for `npm`, so app runtime is unchanged.

This PR self-verifies: `security.yml` runs on PRs to `staging`, so its npm-audit check here executes on `@v5`.

The unused `google-cloudrun-source.yml` stub (SHA-pinned, never triggers) is intentionally left as-is. Latest majors are actually checkout@v7 / setup-node@v6 — staying on v5 as the minimal, low-churn fix that clears the deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)