### PR TITLE
Promote: actions v4 → v5 (clear Node 20 deprecation) to production

### DIFF
--- a/.github/workflows/refresh-county-snapshot.yml
+++ b/.github/workflows/refresh-county-snapshot.yml
@@ -34,12 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout staging
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: staging
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
Promotes #131 — `actions/checkout`/`setup-node` `@v4 → @v5` (Node 24 runtime) — from staging to main, so the deprecation is cleared on the default branch too (where the daily refresh cron and main-branch security runs live). CI-config only; no app/runtime change.

Delta: only the 2 workflow files. Verified on the staging PR: `security.yml`@v5 ran green with no Node 20 deprecation annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)