### PR TITLE
feat(siting): exclude collected (processor waste) residues from inventory

### DIFF
--- a/src/components/SitingInventory.tsx
+++ b/src/components/SitingInventory.tsx
@@ -188,6 +188,9 @@ const SitingInventory: React.FC<SitingInventoryProps> = ({
       for (const factor of residueResult.factors) {
         // Skip entries with no yield data (e.g. "Missing" values that parsed to 0)
         if (!factor.dryTonsPerAcre && !factor.wetTonsPerAcre) continue;
+        // Exclude processor waste (collected===true means hulls, shells, etc. removed
+        // at a processing facility -- not attributable to field acreage).
+        if (factor.collected) continue;
         // Resources-tier rows key composition off the residue's own name;
         // crop-tier rows fall back to the crop's primary resource.
         const apiResource = perResidue


### PR DESCRIPTION
## Summary

- Filters out residues where `collected === true` (shells, hulls, etc.) from the siting mode feedstock inventory
- These residues are removed at a processing facility and cannot be geographically attributed to field acreage -- including them was inflating tonnage estimates significantly (e.g. almond hulls/shells were counted alongside on-field branches)
- Only `collected === false` residues (left-on-field waste: branches, wood chips, trimmings) are now shown

## Implementation

One-line change in `SitingInventory.tsx` `baseResidueRows` useMemo: `if (factor.collected) continue;`

The `collected` boolean is already parsed from `resource_info.json` in `residue-data.ts` and flows through both resolution paths (per-polygon `getResidueFactorsByResourceNames` and crop-name fallback `getCropResidueFactors`). Fallback data defaults to `collected: false` so fallback rows are unaffected.

## Test plan

- [ ] Open Siting Analysis, drop a pin in an almond-growing area (e.g. Fresno County)
- [ ] Confirm "Almond Hulls" and "Almond Shells" no longer appear in the inventory
- [ ] Confirm "Almond Branches" or other on-field residues still appear
- [ ] Confirm total dry residue tonnage is materially lower than before
- [ ] Export CSV and verify it matches the filtered table

*Co-authored with Codex.*