### PR TITLE
feat(siting): exclude collected (processor waste) residues from inventory

### DIFF
--- a/src/components/SitingInventory.tsx
+++ b/src/components/SitingInventory.tsx
@@ -188,6 +188,9 @@ const SitingInventory: React.FC<SitingInventoryProps> = ({
       for (const factor of residueResult.factors) {
         // Skip entries with no yield data (e.g. "Missing" values that parsed to 0)
         if (!factor.dryTonsPerAcre && !factor.wetTonsPerAcre) continue;
+        // Exclude processor waste (collected===true means hulls, shells, etc. removed
+        // at a processing facility -- not attributable to field acreage).
+        if (factor.collected) continue;
         // Resources-tier rows key composition off the residue's own name;
         // crop-tier rows fall back to the crop's primary resource.
         const apiResource = perResidue


### PR DESCRIPTION
## Summary

- Filters `collected === true` residues (hulls, shells -- processor waste) out of the siting mode feedstock inventory
- On-field residues only (`collected === false`): branches, woodchips, straw, prunings
- Eliminates double-counting that inflated tonnage estimates (e.g. almond hulls + shells were included alongside on-field branches)

## Content Delta

- `src/components/SitingInventory.tsx` -- 3-line change: `if (factor.collected) continue` in `baseResidueRows` useMemo

## Ancestry Diagnostics

- Diagnostic commit count: 1

## Test plan

- [x] Staging browser-verified: "Almond Hulls" and "Almond Shells" absent from inventory (JS confirmed `hasAlmondHulls: false`, `hasAlmondShells: false`)
- [x] On-field almond residues still present: "Almond woodchips", "Almond Branches"
- [ ] Confirm total tonnage is materially lower than before the fix

*Co-authored with Codex.*