### PR TITLE
fix(layers): only toggle crop-residue checkboxes on user action

### DIFF
--- a/src/components/LayerControls.tsx
+++ b/src/components/LayerControls.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import React, { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { Card } from "@/components/ui/card";
 import {
   Accordion,
@@ -243,46 +243,6 @@ const LayerControls: React.FC<LayerControlsProps> = ({
     return true; // Crop matches all filter criteria
   }, [monthRange, selectedFeedstockCategories, compositionLookup, compositionFilters]);
   
-  // Function to apply seasonal filter based on month range
-  const applySeasonalFilter = (range: [number, number]) => {
-    setCropVisibility(prev => {
-      const newState = { ...prev };
-      
-      // Update visibility for each crop based on seasonal availability
-      allCropNames.forEach(cropName => {
-        newState[cropName] = isCropAvailableInRange(cropName, range);
-      });
-      
-      // Get visible crops after applying seasonal filter
-      const visibleCrops = Object.keys(newState).filter(name => newState[name]);
-      
-      // Try to directly update the map filter for crop visibility
-      const mapInstance = getMapInstance();
-      if (mapInstance && mapInstance.getLayer('feedstock-vector-layer')) {
-        try {
-          // Make sure the layer is visible if the feedstock layer is enabled and there are visible crops
-          if (visibleCrops.length > 0 && localLayerVisibility.feedstock) {
-            mapInstance.setLayoutProperty('feedstock-vector-layer', 'visibility', 'visible');
-          }
-          
-          // Create a filter that shows only visible crops
-          const visibleCropFilter = visibleCrops.length > 0
-            ? ['match', ['get', 'main_crop_name'], visibleCrops, true, false]
-            : ['==', ['get', 'main_crop_name'], '___NO_MATCH___']; // Hide all
-          // Combine with the existing base filter that excludes 'U' code
-          const combinedFilter = ['all', ['!=', ['get', 'main_crop_code'], 'U'], visibleCropFilter];
-          
-          // Apply the filter directly to the map
-          mapInstance.setFilter('feedstock-vector-layer', combinedFilter);
-          console.log(`Directly updated crop filter based on seasonal availability (${visibleCrops.length} crops visible)`);
-        } catch (err) {
-          console.error('Error directly updating crop filter:', err);
-        }
-      }
-      
-      return newState;
-    });
-  };
   
   // Comprehensive function to apply all filters (seasonal + characteristics)
   const applyAllFilters = useCallback(() => {
@@ -388,20 +348,42 @@ const LayerControls: React.FC<LayerControlsProps> = ({
     onCropFilterChange(visibleCrops);
   }, [allCropNames, cropVisibility, onCropFilterChange]); // Added missing dependencies
   
-  // Apply seasonal filter when component mounts
+  // Keep a ref to the latest applyAllFilters so the effect below can call it
+  // WITHOUT depending on it. Depending on applyAllFilters would re-run filtering
+  // whenever compositionLookup loads asynchronously, or the feedstock layer's
+  // visibility changes (e.g. entering siting/analysis mode) — which would
+  // spontaneously uncheck crop boxes. We only want filtering to re-apply when a
+  // user actually moves a filter control.
+  const applyAllFiltersRef = useRef(applyAllFilters);
+  applyAllFiltersRef.current = applyAllFilters;
+
+  // Re-apply crop filtering ONLY in response to a real user action on a filter
+  // control: the seasonal month range, the feedstock-category checkboxes, or the
+  // composition sliders. These three pieces of state change exclusively on user
+  // interaction. We deliberately do NOT depend on compositionLookup (async data
+  // load) or layer visibility, so page load, zoom, and siting/analysis mode can
+  // no longer auto-uncheck crop boxes — those toggle on user action only.
+  const prevFilterInputsRef = useRef({ monthRange, selectedFeedstockCategories, compositionFilters });
   useEffect(() => {
-    applySeasonalFilter(monthRange);
-  }, []);
-  
-  // Apply all filters when any filter state changes
-  useEffect(() => {
-    // Wait a bit for the map to be ready on initial load
+    const prev = prevFilterInputsRef.current;
+    const userChangedFilter =
+      prev.monthRange !== monthRange ||
+      prev.selectedFeedstockCategories !== selectedFeedstockCategories ||
+      prev.compositionFilters !== compositionFilters;
+    prevFilterInputsRef.current = { monthRange, selectedFeedstockCategories, compositionFilters };
+
+    // Skip the initial mount run (and any re-run where the inputs are identical,
+    // e.g. React StrictMode's double-invoke) so crops start — and stay — visible
+    // until the user touches a filter.
+    if (!userChangedFilter) return;
+
+    // Small delay so the map instance is ready when applying the derived filter.
     const timeoutId = setTimeout(() => {
-      applyAllFilters();
+      applyAllFiltersRef.current();
     }, 100);
-    
+
     return () => clearTimeout(timeoutId);
-  }, [applyAllFilters]);
+  }, [monthRange, selectedFeedstockCategories, compositionFilters]);
   
   // Store a reference to the map instance when it becomes available
   useEffect(() => {


### PR DESCRIPTION
## Problem
Crop subtype checkboxes (Grapes, Olives, etc.) were being **unchecked spontaneously** — at page load, on zoom, and when entering siting/analysis mode — making those polygons disappear without any user action. Users expected the boxes to change **only** when they toggle them.

## Root cause
`applyAllFilters` in `LayerControls.tsx` recomputed the entire `cropVisibility` state from filter criteria and re-ran whenever its dependency *identity* changed — including:
- when the **composition dataset finished loading asynchronously** (timing-dependent → looked "random"), and
- when the **feedstock layer's visibility toggled** (siting/analysis mode).

Each run discarded the user's manual selections.

## Fix
- Removed the mount-time seasonal filter effect (and the orphaned `applySeasonalFilter`) so crops start — and stay — visible until the user touches a filter. `applyAllFilters` already covers seasonal availability.
- Re-apply filtering **only** in response to genuine user filter-control changes (month range, feedstock categories, composition sliders), via a previous-inputs ref that skips mount and React StrictMode double-invokes. The effect no longer depends on `compositionLookup` or layer visibility — so async data loads, zoom, and siting/analysis can no longer auto-uncheck crops.

## Verification (live, real Mapbox + backend)
Measured the live crop-filter allow-list (viewport-independent mirror of the checkboxes):
- **After composition data loads:** 56/56 crops checked, Grapes + Olives rendering ✅
- **Zoom z5–z14 + rapid cycles:** holds 56/56 ✅
- **Siting mode + buffer analysis** (the heaviest reproducer): holds 56/56, 17,710 grape polygons rendering ✅
- **Filter feature intact:** unchecking "Tree, Vine & Nut Crops" → 56→34, removes Grapes/Almonds, keeps Rice ✅
- **Manual choice persists** across zoom ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)