### PR TITLE
fix(layers): keep all crop checkboxes on at default (neutral filters)

### DIFF
--- a/src/components/LayerControls.tsx
+++ b/src/components/LayerControls.tsx
@@ -179,6 +179,12 @@ const LayerControls: React.FC<LayerControlsProps> = ({
   
   // Function to check if a crop is available in the selected month range
   const isCropAvailableInRange = (cropName: string, range: [number, number]): boolean => {
+    // Full-year range is the default "no seasonal filter" state — every crop is
+    // available across a whole year, so never hide one here. This guards against
+    // crops whose residue data has missing/odd seasonalAvailability being dropped
+    // at the default range; they only get filtered once the user narrows the months.
+    if (range[0] === 0 && range[1] === 11) return true;
+
     // Use the helper to get factors which now includes seasonal availability from the dynamic source
     const result = getCropResidueFactors(cropName);
     const factorsArray = result?.factors;

--- a/src/lib/composition-filters.ts
+++ b/src/lib/composition-filters.ts
@@ -53,10 +53,14 @@ export interface CompositionFilters {
 }
 
 /** Full-range bounds for each metric — at these values, no crops are hidden. */
+// Upper bounds are chosen to cover the full range of the real residue data so
+// the sliders can reach every crop's value. Lignin in particular goes to 55
+// because woody shells (walnut ≈54, pistachio ≈50) are highly ligneous; a lower
+// cap would make those crops unreachable once the user touches the lignin slider.
 export const COMPOSITION_FILTER_BOUNDS: CompositionFilters = {
   moisture: [0, 80],
   cellulose: [0, 60],
-  lignin: [0, 40],
+  lignin: [0, 55],
   ash: [0, 15],
   hhv: [8, 22],
 };
@@ -64,7 +68,7 @@ export const COMPOSITION_FILTER_BOUNDS: CompositionFilters = {
 export const DEFAULT_COMPOSITION_FILTERS: CompositionFilters = {
   moisture: [0, 80],
   cellulose: [0, 60],
-  lignin: [0, 40],
+  lignin: [0, 55],
   ash: [0, 15],
   hhv: [8, 22],
 };
@@ -160,6 +164,12 @@ export function cropPassesCompositionFilters(
   lookup: CompositionLookup,
   filters: CompositionFilters
 ): boolean {
+  // When the composition filter is at its full-range default it must never hide
+  // a crop — not even one whose measured value sits outside the nominal bounds
+  // (e.g. walnut/pistachio shells with lignin above the slider max). Crops are
+  // only excluded once the user actively narrows a slider.
+  if (!isCompositionFiltersActive(filters)) return true;
+
   // Use API data first, then literature fallback, then pass-through
   const apiComp = lookup[landiqCropName];
   const comp: Partial<CompositionData> | undefined =


### PR DESCRIPTION
Follow-up to #143. Even with the auto-unchecking on load fixed, specific crops (**Walnuts, Pistachios, Grapes, Olives, Cotton, Almonds**) could still be unchecked because a filter sitting at its **default/full-range** setting could return `false` for a crop — so the moment any filter ran, those crops vanished without the user narrowing anything.

## Root causes (surfaced by the latest LandIQ dataset)
- **Composition:** walnut/pistachio shells are highly ligneous (lignin ≈ 54/50), but `COMPOSITION_FILTER_BOUNDS` capped lignin at **40** — so they failed the composition filter even at its full-range default.
- **Seasonal:** crops whose residue data has wrapped/odd month windows could fail `isCropAvailableInRange` even for the full-year default range.

## Fix — every filter is now a true no-op at its default
- `cropPassesCompositionFilters`: short-circuit to `true` when the filter is not active (equals its full-range bounds) — default never hides a crop, regardless of measured value.
- Widen lignin bound **40 → 55** so the slider can reach woody shells.
- `isCropAvailableInRange`: the full-year range (Jan–Dec) always returns available.

A crop is now hidden **only** when the user manually unchecks it or actively narrows a specific filter.

## Verified live (per-crop legend — the UI in the reports)
- All **56** crops checked at page load (incl. Grapes, Olives, Cotton, Walnuts, Almonds, Pistachios) ✅
- Unchecking the **Grain & Field** category drops *exactly* its 9 crops; **Walnuts/Pistachios/Grapes/Olives survive** (old code dropped Walnuts/Pistachios here via the lignin bound) ✅
- Re-checking the category restores all 56 ✅
- Manual uncheck of a single crop affects only that crop ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
