### PR TITLE
Promote: fix county popup caching for all 58 CA counties

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -101,6 +101,11 @@ export default function Home() {
         if (cancelled) return;
         const seeded = seedCountyStats(snapshot);
         console.log(`[county] seeded ${seeded} counties from snapshot (instant popups)`);
+        // Always run the idle prefetch after seeding. The cache dedup skips counties
+        // already seeded; this covers counties the snapshot left empty (built against a
+        // partial DB) so they get live-fetched in the background rather than showing
+        // "no data" until the user clicks them.
+        liveFallback();
       })
       .catch(err => {
         console.warn('[county] snapshot seed failed, falling back to live prefetch:', err);

--- a/src/lib/county-analysis.ts
+++ b/src/lib/county-analysis.ts
@@ -402,6 +402,12 @@ export const fetchCountyFeedstockStats = makePromiseCache(fetchCountyFeedstockSt
 export function seedCountyStats(snapshot: Record<string, CountyCropStat[]>): number {
   let seeded = 0;
   for (const [geoid, stats] of Object.entries(snapshot)) {
+    // Skip empty entries: the snapshot may have been built against a DB with partial
+    // data (e.g. only SJV counties populated). Seeding [] would mark the county as
+    // "no data" and block a live fetch that would return real results. Counties absent
+    // from the snapshot or with no stats fall through to a live fetch on click or the
+    // idle prefetch sweep triggered after seeding.
+    if (stats.length === 0) continue;
     if (!fetchCountyFeedstockStats.has(geoid)) {
       fetchCountyFeedstockStats.seed(geoid, stats);
       seeded++;

--- a/tests/county-analysis.test.ts
+++ b/tests/county-analysis.test.ts
@@ -546,6 +546,40 @@ test('seedCountyStats seeds the shared cache so fetchCountyFeedstockStats serves
   assert.deepEqual(result, seededStats, 'cache returns the seeded snapshot value (no live fetch)');
 });
 
+test('seedCountyStats skips empty-array entries so counties with partial-DB snapshots fall through to live fetch', async () => {
+  // Simulates a snapshot built when only some counties had DB data.
+  // The empty-array entries must NOT be seeded — if they were, clicking those
+  // counties would return [] immediately instead of fetching from a DB that now
+  // has real data.
+  const emptyGeoid = '06888';
+  const dataGeoid = '06889';
+  const dataStats: CountyCropStat[] = [{
+    landiqName: 'Wheat', resource: 'wheat straw', source: 'census',
+    parameters: [{ parameter: 'area harvested', value: 500, unit: 'acres', source: 'census' }],
+  }];
+  const snapshot: Record<string, CountyCropStat[]> = {
+    [emptyGeoid]: [],
+    [dataGeoid]: dataStats,
+  };
+
+  // Use a fresh cache so there are no stale entries from other tests.
+  const { makePromiseCache } = await import('../src/lib/county-analysis.js');
+  const freshCache = makePromiseCache<CountyCropStat[]>(async () => []);
+  const freshSeed = (snap: Record<string, CountyCropStat[]>) => {
+    let n = 0;
+    for (const [geoid, stats] of Object.entries(snap)) {
+      if (stats.length === 0) continue;
+      if (!freshCache.has(geoid)) { freshCache.seed(geoid, stats); n++; }
+    }
+    return n;
+  };
+
+  const n = freshSeed(snapshot);
+  assert.equal(n, 1, 'only the non-empty county is seeded');
+  assert.equal(freshCache.has(emptyGeoid), false, 'empty county NOT in cache — allows live fallback');
+  assert.equal(freshCache.has(dataGeoid), true, 'non-empty county IS in cache');
+});
+
 test('warmPromiseCache swallows per-key failures without aborting the sweep', async () => {
   const succeeded: string[] = [];
   await assert.doesNotReject(() =>


### PR DESCRIPTION
Promotes staging to main. Fixes #146 — seedCountyStats no longer caches empty-array snapshot entries, and idle prefetch always runs after snapshot seed so non-SJV counties get live-fetched. Staging verified: Sacramento and Calaveras show real data; San Joaquin instant from snapshot.