### PR TITLE
ci(county): split snapshot refresh into staging and production workflows

### DIFF
--- a/.github/workflows/refresh-county-snapshot-prod.yml
+++ b/.github/workflows/refresh-county-snapshot-prod.yml
@@ -1,0 +1,77 @@
+name: Refresh county-stats snapshot (production)
+
+# Mirror of refresh-county-snapshot.yml but targets the PRODUCTION backend
+# (api.calbioscape.org) and commits directly to `main`.
+#
+# Why a separate workflow: staging and production backends carry different
+# subsets of CA county data. Staging may have all 58 counties populated before
+# production does. Each environment should reflect its own backend's data so
+# that the snapshot accurately represents what the live API will return for a
+# cache miss, and so that populating the production DB automatically propagates
+# to the production snapshot within 24 hours.
+#
+# Flow:
+#   1. Staging promotes to main (brings staging snapshot, possibly richer).
+#   2. This workflow fires on schedule and overwrites with production data.
+#   3. Once production DB reaches parity with staging, both snapshots converge.
+#
+# Required repo secrets (same as the main API credentials):
+#   CA_BIOSITE_API_KEY            (preferred), or
+#   CA_BIOSITE_API_USER + CA_BIOSITE_API_PASSWORD  (JWT fallback)
+
+on:
+  schedule:
+    # Daily at 09:30 UTC — 30 min after the staging workflow so they don't
+    # race on the same build queue. Bounds production snapshot staleness to <= 24h.
+    - cron: '30 9 * * *'
+  workflow_dispatch: {}
+
+# Serialize refreshes; never run two snapshot pushes against main at once.
+concurrency:
+  group: refresh-county-snapshot-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    name: Regenerate and publish snapshot (production API)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Regenerate county-stats snapshot
+        env:
+          NEXT_PUBLIC_API_BASE_URL: https://api.calbioscape.org
+          CA_BIOSITE_API_KEY: ${{ secrets.CA_BIOSITE_API_KEY }}
+          CA_BIOSITE_API_USER: ${{ secrets.CA_BIOSITE_API_USER }}
+          CA_BIOSITE_API_PASSWORD: ${{ secrets.CA_BIOSITE_API_PASSWORD }}
+        # The script's guard exits non-zero (failing this job loudly) on a
+        # truncated or all-empty-vs-previous sweep, so a degraded snapshot is
+        # never committed.
+        run: npm run build-county-snapshot
+
+      - name: Commit and push if the snapshot changed
+        run: |
+          if git diff --quiet -- public/data/county-stats-snapshot.json; then
+            echo "Snapshot unchanged — nothing to publish."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/data/county-stats-snapshot.json
+          git commit -m "chore(county): refresh county-stats snapshot from production API [automated]"
+          git push origin HEAD:main

--- a/.github/workflows/refresh-county-snapshot.yml
+++ b/.github/workflows/refresh-county-snapshot.yml
@@ -1,4 +1,4 @@
-name: Refresh county-stats snapshot
+name: Refresh county-stats snapshot (staging)
 
 # Keeps the client-side county-stats lookup table
 # (public/data/county-stats-snapshot.json) fresh with the backend USDA data
@@ -6,13 +6,16 @@ name: Refresh county-stats snapshot
 # ever putting the slow (~16s-p90) backend on a user's request path. The sweep
 # runs here, offline; users keep reading one small static asset.
 #
-# Required repo/org secrets (one auth path):
-#   CA_BIOSITE_API_KEY                       (preferred), or
-#   CA_BIOSITE_API_USER + CA_BIOSITE_API_PASSWORD
-# Optional repo variable:
-#   CA_BIOSITE_API_BASE_URL  (defaults to the prod base below)
+# This workflow builds against the STAGING backend (api-staging.calbioscape.org),
+# which carries the full set of CA county data. The companion workflow
+# `refresh-county-snapshot-prod.yml` does the same against production.
 #
-# Publishes to `staging`; prod picks it up on the next staging -> main promotion.
+# Required repo secret:
+#   CA_BIOSITE_API_KEY_STAGING   (preferred), or
+#   CA_BIOSITE_API_USER + CA_BIOSITE_API_PASSWORD  (JWT fallback)
+#
+# Publishes to `staging`; prod picks it up on the next staging -> main promotion,
+# then `refresh-county-snapshot-prod.yml` overwrites with production data.
 
 on:
   schedule:
@@ -22,7 +25,7 @@ on:
 
 # Serialize refreshes; never run two snapshot pushes against staging at once.
 concurrency:
-  group: refresh-county-snapshot
+  group: refresh-county-snapshot-staging
   cancel-in-progress: false
 
 permissions:
@@ -30,7 +33,7 @@ permissions:
 
 jobs:
   refresh:
-    name: Regenerate and publish snapshot
+    name: Regenerate and publish snapshot (staging API)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout staging
@@ -49,11 +52,8 @@ jobs:
 
       - name: Regenerate county-stats snapshot
         env:
-          # `|| 'prod'` so an unset repo variable falls back to prod rather than
-          # passing an empty string (the script uses `?? prod`, which an empty
-          # string would not trigger).
-          NEXT_PUBLIC_API_BASE_URL: ${{ vars.CA_BIOSITE_API_BASE_URL || 'https://api.calbioscape.org' }}
-          CA_BIOSITE_API_KEY: ${{ secrets.CA_BIOSITE_API_KEY }}
+          NEXT_PUBLIC_API_BASE_URL: https://api-staging.calbioscape.org
+          CA_BIOSITE_API_KEY: ${{ secrets.CA_BIOSITE_API_KEY_STAGING }}
           CA_BIOSITE_API_USER: ${{ secrets.CA_BIOSITE_API_USER }}
           CA_BIOSITE_API_PASSWORD: ${{ secrets.CA_BIOSITE_API_PASSWORD }}
         # The script's guard exits non-zero (failing this job loudly) on a
@@ -70,5 +70,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add public/data/county-stats-snapshot.json
-          git commit -m "chore(county): refresh county-stats snapshot [automated]"
+          git commit -m "chore(county): refresh county-stats snapshot from staging API [automated]"
           git push origin HEAD:staging


### PR DESCRIPTION
Adds a production-equivalent of the county snapshot refresh workflow.

**staging workflow** (modified): now uses `CA_BIOSITE_API_KEY_STAGING` + `api-staging.calbioscape.org` — staging snapshot will reflect the full 58-county staging DB.

**production workflow** (new): `refresh-county-snapshot-prod.yml` — uses `CA_BIOSITE_API_KEY` + `api.calbioscape.org`, checks out `main`, runs daily at 09:30 UTC (30 min after staging). Commits directly to `main` (branch protection allows it — no required PR reviews, no push restrictions).

**Guard behavior**: if production API returns all-empty (backend down/wrong creds), the guard in `county-snapshot-guard.ts` exits non-zero and nothing is committed.

**Convergence**: once production DB reaches parity with staging, both snapshots will have all 58 counties and instant popups everywhere.