### PR TITLE
fix(county-popups): seed empty snapshot entries so ALL counties open instantly

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -101,10 +101,11 @@ export default function Home() {
         if (cancelled) return;
         const seeded = seedCountyStats(snapshot);
         console.log(`[county] seeded ${seeded} counties from snapshot (instant popups)`);
-        // Always run the idle prefetch after seeding. The cache dedup skips counties
-        // already seeded; this covers counties the snapshot left empty (built against a
-        // partial DB) so they get live-fetched in the background rather than showing
-        // "no data" until the user clicks them.
+        // Run the idle prefetch as defense-in-depth. seedCountyStats seeds every
+        // snapshot entry — including no-data counties (as authoritative `[]`) — so
+        // for a complete snapshot the cache dedup makes this a no-op (no request
+        // storm). It only does real work for any clickable geoid the snapshot
+        // somehow failed to cover.
         liveFallback();
       })
       .catch(err => {

--- a/src/lib/county-analysis.ts
+++ b/src/lib/county-analysis.ts
@@ -398,16 +398,22 @@ export const fetchCountyFeedstockStats = makePromiseCache(fetchCountyFeedstockSt
  * underlying data changes, which is at most annual. Returns the number of
  * counties seeded. Geoids absent from the snapshot still fall back to a live
  * fetch via fetchCountyFeedstockStats.
+ *
+ * Seeds EVERY entry, including counties with no crop data (`[]`). A committed
+ * empty array is an authoritative "no USDA cropland reported", not a transient
+ * miss: the snapshot builder sweeps all 58 counties and aborts the whole build
+ * if any county fetch throws, and the snapshot guard rejects an all-empty or
+ * sharply data-regressed sweep (see county-snapshot-guard.ts). Seeding the
+ * empties is what makes EVERY county — not just the few with data — open its
+ * popup instantly: a no-data county resolves to `[]` from memory instead of
+ * falling through to ~36 live queries (~16s p90) that return nothing anyway.
+ * It also makes the post-seed idle prefetch a no-op for snapshot-covered
+ * counties, eliminating the page-load request storm that warming all 58
+ * counties live would otherwise cause.
  */
 export function seedCountyStats(snapshot: Record<string, CountyCropStat[]>): number {
   let seeded = 0;
   for (const [geoid, stats] of Object.entries(snapshot)) {
-    // Skip empty entries: the snapshot may have been built against a DB with partial
-    // data (e.g. only SJV counties populated). Seeding [] would mark the county as
-    // "no data" and block a live fetch that would return real results. Counties absent
-    // from the snapshot or with no stats fall through to a live fetch on click or the
-    // idle prefetch sweep triggered after seeding.
-    if (stats.length === 0) continue;
     if (!fetchCountyFeedstockStats.has(geoid)) {
       fetchCountyFeedstockStats.seed(geoid, stats);
       seeded++;

--- a/src/lib/county-snapshot-guard.ts
+++ b/src/lib/county-snapshot-guard.ts
@@ -15,6 +15,18 @@ import type { CountyCropStat } from './county-analysis';
 /** California has 58 counties; the snapshot must cover every one. */
 export const EXPECTED_COUNTY_COUNT = 58;
 
+/**
+ * Minimum fraction of the previous snapshot's data-bearing counties a new
+ * snapshot must retain. A degraded sweep (transient backend errors that the
+ * per-resource fetch swallows rather than throws) can record a county that
+ * truly has data as an empty `[]` without failing the build. Because the client
+ * now seeds empty entries as authoritative "no data" (instant popups), such a
+ * collapse must be caught here, at build time, before it ships. A drop below
+ * this fraction signals a partial/degraded sweep and refuses the overwrite;
+ * normal day-to-day fluctuation stays well above it.
+ */
+export const MIN_DATA_COVERAGE_RATIO = 0.5;
+
 export type CountySnapshot = Record<string, CountyCropStat[]>;
 
 export interface SnapshotValidation {
@@ -49,10 +61,14 @@ export function serializeCountySnapshot(snapshot: CountySnapshot): string {
  * Rejects when:
  *  - it covers fewer than {@link EXPECTED_COUNTY_COUNT} counties (truncated sweep), or
  *  - it has zero counties with data while the previous snapshot had some
- *    (a degraded sweep that would wipe real data).
+ *    (a degraded sweep that would wipe real data), or
+ *  - its data coverage collapses below {@link MIN_DATA_COVERAGE_RATIO} of the
+ *    previous snapshot's (a partial sweep that silently dropped real counties
+ *    to empty — which the client would otherwise ship as authoritative "no
+ *    data").
  *
  * `prev` is `null` on the first ever build — there is nothing to degrade from,
- * so the all-empty check is skipped.
+ * so the regression checks are skipped.
  */
 export function validateCountySnapshot(
   next: CountySnapshot,
@@ -72,6 +88,13 @@ export function validateCountySnapshot(
     return {
       ok: false,
       reason: `snapshot has 0 counties with data but the previous snapshot had ${prevWithData} — refusing to overwrite (likely a partial or failed backend sweep)`,
+    };
+  }
+
+  if (prevWithData > 0 && nextWithData < prevWithData * MIN_DATA_COVERAGE_RATIO) {
+    return {
+      ok: false,
+      reason: `snapshot data coverage collapsed from ${prevWithData} to ${nextWithData} counties (below ${Math.round(MIN_DATA_COVERAGE_RATIO * 100)}% retention) — refusing to overwrite (likely a partial or degraded backend sweep)`,
     };
   }
 

--- a/tests/county-analysis.test.ts
+++ b/tests/county-analysis.test.ts
@@ -546,11 +546,12 @@ test('seedCountyStats seeds the shared cache so fetchCountyFeedstockStats serves
   assert.deepEqual(result, seededStats, 'cache returns the seeded snapshot value (no live fetch)');
 });
 
-test('seedCountyStats skips empty-array entries so counties with partial-DB snapshots fall through to live fetch', async () => {
-  // Simulates a snapshot built when only some counties had DB data.
-  // The empty-array entries must NOT be seeded — if they were, clicking those
-  // counties would return [] immediately instead of fetching from a DB that now
-  // has real data.
+test('seedCountyStats seeds empty-array entries so no-data counties open instantly without a live fetch', async () => {
+  // A committed empty array is an authoritative "no USDA cropland reported": the
+  // builder aborts on any fetch error and the guard rejects a degraded sweep, so
+  // an empty entry is never a transient miss. Seeding it is what makes EVERY
+  // county instant — a no-data county must resolve to [] from cache rather than
+  // firing ~36 live queries (~16s p90) that return nothing.
   const emptyGeoid = '06888';
   const dataGeoid = '06889';
   const dataStats: CountyCropStat[] = [{
@@ -562,22 +563,14 @@ test('seedCountyStats skips empty-array entries so counties with partial-DB snap
     [dataGeoid]: dataStats,
   };
 
-  // Use a fresh cache so there are no stale entries from other tests.
-  const { makePromiseCache } = await import('../src/lib/county-analysis.js');
-  const freshCache = makePromiseCache<CountyCropStat[]>(async () => []);
-  const freshSeed = (snap: Record<string, CountyCropStat[]>) => {
-    let n = 0;
-    for (const [geoid, stats] of Object.entries(snap)) {
-      if (stats.length === 0) continue;
-      if (!freshCache.has(geoid)) { freshCache.seed(geoid, stats); n++; }
-    }
-    return n;
-  };
+  const n = seedCountyStats(snapshot);
+  assert.equal(n, 2, 'both the empty and the non-empty county are seeded');
+  assert.equal(fetchCountyFeedstockStats.has(emptyGeoid), true, 'empty county IS in cache — served instantly');
+  assert.equal(fetchCountyFeedstockStats.has(dataGeoid), true, 'non-empty county IS in cache');
 
-  const n = freshSeed(snapshot);
-  assert.equal(n, 1, 'only the non-empty county is seeded');
-  assert.equal(freshCache.has(emptyGeoid), false, 'empty county NOT in cache — allows live fallback');
-  assert.equal(freshCache.has(dataGeoid), true, 'non-empty county IS in cache');
+  // The empty county resolves to [] from memory with no live fetch.
+  assert.deepEqual(await fetchCountyFeedstockStats(emptyGeoid), [], 'empty county returns [] from cache');
+  assert.deepEqual(await fetchCountyFeedstockStats(dataGeoid), dataStats, 'data county returns seeded stats from cache');
 });
 
 test('warmPromiseCache swallows per-key failures without aborting the sweep', async () => {

--- a/tests/county-snapshot-guard.test.ts
+++ b/tests/county-snapshot-guard.test.ts
@@ -6,6 +6,7 @@ import {
   countCountiesWithData,
   serializeCountySnapshot,
   EXPECTED_COUNTY_COUNT,
+  MIN_DATA_COVERAGE_RATIO,
   type CountySnapshot,
 } from '../src/lib/county-snapshot-guard';
 import type { CountyCropStat } from '../src/lib/county-analysis';
@@ -52,6 +53,29 @@ test('accepts an all-empty snapshot when there is no previous snapshot (first bu
 test('accepts an all-empty snapshot when the previous was also all-empty', () => {
   const result = validateCountySnapshot(snapshotOf(0), snapshotOf(0));
   assert.equal(result.ok, true, result.reason);
+});
+
+test('rejects a snapshot whose data coverage collapses below the retention floor (partial sweep)', () => {
+  // 40 -> 10 is a 75% drop, below the 50% retention floor. Because the client now
+  // ships empty entries as authoritative "no data", this degraded sweep must be
+  // caught here rather than silently marking 30 real counties as no-data.
+  const result = validateCountySnapshot(snapshotOf(10), snapshotOf(40));
+  assert.equal(result.ok, false);
+  assert.match(result.reason ?? '', /collapsed from 40 to 10/);
+});
+
+test('accepts a minor data-coverage fluctuation above the retention floor', () => {
+  const result = validateCountySnapshot(snapshotOf(38), snapshotOf(40));
+  assert.equal(result.ok, true, result.reason);
+});
+
+test('retention floor: 3 -> 2 accepted, 3 -> 1 rejected', () => {
+  assert.equal(validateCountySnapshot(snapshotOf(2), snapshotOf(3)).ok, true);
+  assert.equal(validateCountySnapshot(snapshotOf(1), snapshotOf(3)).ok, false);
+});
+
+test('MIN_DATA_COVERAGE_RATIO is a fraction in (0, 1]', () => {
+  assert.ok(MIN_DATA_COVERAGE_RATIO > 0 && MIN_DATA_COVERAGE_RATIO <= 1);
 });
 
 test('countCountiesWithData counts only counties with at least one crop row', () => {


### PR DESCRIPTION
## Problem

County USDA stat popups loaded **WAY slower for counties outside the northern San Joaquin Valley**. Popups seed a static snapshot (`public/data/county-stats-snapshot.json`) into an in-memory cache on page load, but a prior fix (#149 / commits `34dda2d`/`b46c286`) made `seedCountyStats` **skip empty-array entries**.

Prod only has USDA data for **3 northern SJV counties** (Merced/San Joaquin/Stanislaus); the other **55 counties are empty arrays** in the snapshot. Skipping them meant every non-SJV county click fell through to a **live fetch** — ~36 backend requests against the unindexed bio-siting tables (p90 ~16s) that returned *nothing* — plus the "always run idle prefetch" live-fetched all 55 empties in the background, a **~2000-request storm on every page load**.

## Fix

- **Seed every snapshot entry, including `[]`.** A committed empty array is an authoritative "No USDA cropland reported", not a transient miss. Every county now resolves from memory **instantly**, and the idle prefetch becomes a no-op for snapshot-covered counties (storm eliminated).
- **Move degraded-sweep safety to build time** (where it belongs): `validateCountySnapshot` now rejects a build whose data-bearing county count collapses below 50% of the previous snapshot (`MIN_DATA_COVERAGE_RATIO`), on top of the existing all-empty and truncation guards. A bad/partial backend sweep is caught before it ships instead of punishing every user session with 16s loads. A one-day-stale empty self-heals via the daily refresh workflows.
- `page.tsx`: idle prefetch is now defense-in-depth (no-op for complete snapshots; real work only when the snapshot is missing/failed).

`Map.js` already renders **"No USDA cropland reported for this county."** for the empty/null aggregate — so no-data counties show a clean message in milliseconds rather than after a 16s live fetch.

## Files
- `src/lib/county-analysis.ts` — `seedCountyStats` seeds empties
- `src/lib/county-snapshot-guard.ts` — coverage-regression guard + `MIN_DATA_COVERAGE_RATIO`
- `src/app/page.tsx` — idle prefetch comment/role
- `tests/county-analysis.test.ts`, `tests/county-snapshot-guard.test.ts`

## Testing
- County test suites: **52/52 pass** (`county-analysis`, `county-snapshot-guard`).
- Full suite 146/148 — the 2 failures (`carb`/`epa` build tests) fail identically on a clean tree (missing `csv-parse` dep in this worktree), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)