### PR TITLE
fix(composition): hide sulfur metric until unit conversions resolved

### DIFF
--- a/src/components/FeedstockCompositionPanel.tsx
+++ b/src/components/FeedstockCompositionPanel.tsx
@@ -108,15 +108,16 @@ const METRICS: Array<{ key: keyof CompositionData; config: MetricConfig }> = [
       rate: (v) => v <= 1 ? 'green' : v <= 2 ? 'amber' : 'neutral',
     },
   },
-  {
-    key: 'sulfur',
-    config: {
-      label: 'Sulfur (S)',
-      unit: '%',
-      tooltip: 'Low sulfur reduces SO₂ emissions during combustion.',
-      rate: (v) => v <= 0.2 ? 'green' : v <= 0.5 ? 'amber' : 'red',
-    },
-  },
+  // TODO: Sulfur hidden until unit conversions are resolved
+  // {
+  //   key: 'sulfur',
+  //   config: {
+  //     label: 'Sulfur (S)',
+  //     unit: '%',
+  //     tooltip: 'Low sulfur reduces SO₂ emissions during combustion.',
+  //     rate: (v) => v <= 0.2 ? 'green' : v <= 0.5 ? 'amber' : 'red',
+  //   },
+  // },
   {
     key: 'hhv',
     config: {


### PR DESCRIPTION
## Summary
- Comments out the Sulfur (S) row in the `METRICS` array in `FeedstockCompositionPanel.tsx`
- Sulfur values are erroneous due to unresolved unit conversion issues
- Code is commented out (not deleted) so it can be restored once units are sorted

## Test plan
- [ ] Open a siting inventory and check the Biomass Composition panel — Sulfur row should no longer appear
- [ ] All other composition metrics (C, H, O, N, Ash, Moisture, HHV) should still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)