### PR TITLE
fix(composition): fixed colors for Moisture (blue) and Lignin (green) boxes

### DIFF
--- a/src/components/FeedstockCompositionPanel.tsx
+++ b/src/components/FeedstockCompositionPanel.tsx
@@ -7,7 +7,7 @@ import { CompositionData } from '@/lib/composition-filters';
 // Metric display config
 // ---------------------------------------------------------------------------
 
-type RatingColor = 'green' | 'amber' | 'red' | 'neutral';
+type RatingColor = 'green' | 'amber' | 'red' | 'neutral' | 'blue';
 
 interface MetricConfig {
   label: string;
@@ -42,7 +42,7 @@ const METRICS: Array<{ key: keyof CompositionData; config: MetricConfig }> = [
       label: 'Lignin',
       unit: '%',
       tooltip: 'Low lignin benefits biochemical conversion; high lignin suits gasification/pyrolysis.',
-      rate: (v) => v <= 15 ? 'green' : v <= 25 ? 'amber' : 'red',
+      rate: (_v) => 'green',
     },
   },
   {
@@ -60,7 +60,7 @@ const METRICS: Array<{ key: keyof CompositionData; config: MetricConfig }> = [
       label: 'Moisture',
       unit: '%',
       tooltip: 'Low moisture is ideal for thermal processes; high moisture suits anaerobic digestion.',
-      rate: (v) => v <= 15 ? 'green' : v <= 30 ? 'amber' : 'neutral',
+      rate: (_v) => 'blue',
     },
   },
   {
@@ -134,6 +134,7 @@ const COLOR_CLASSES: Record<RatingColor, string> = {
   amber:   'bg-amber-50 text-amber-800 border-amber-200',
   red:     'bg-red-50 text-red-800 border-red-200',
   neutral: 'bg-gray-50 text-gray-700 border-gray-200',
+  blue:    'bg-blue-50 text-blue-800 border-blue-200',
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #154

## Changes
- `Moisture` → always `blue` (`bg-blue-50 text-blue-800 border-blue-200`), regardless of value
- `Lignin` → always `green` (`bg-green-50 text-green-800 border-green-200`), regardless of value
- Added `'blue'` to `RatingColor` type and `COLOR_CLASSES` map

## Test plan
- [ ] Open a siting inventory on staging — Moisture box should be light blue, Lignin box should be light green for any feedstock
- [ ] Verify other composition boxes (Cellulose, Ash, HHV, etc.) still show dynamic value-based colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)