### PR TITLE
fix(map): collapse LandIQ crop popup into aggregate totals + collapsible sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /coverage
 /playwright-report/
 /test-results/
+/e2e/__artifacts__/
 
 # next.js
 /.next/

--- a/e2e/tests/feedstock-popup.spec.ts
+++ b/e2e/tests/feedstock-popup.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '../fixtures/index';
+
+// Regression test for issue #153: the LandIQ "Crop Field Details" popup must show
+// compact AGGREGATE residue totals up top plus collapsible <details> sections, rather
+// than one mile-tall flat list. Verified against a multi-residue crop (almonds), which
+// has several residue streams (hulls, shells, prunings) and used to overflow the map.
+//
+// Canvas clicks are flaky in CI (see county-layer.spec.ts), so instead of a blind mouse
+// click we query rendered feedstock features for an almond field, project its centroid to
+// a pixel, and dispatch a real click there — deterministic and stable.
+
+type MapboxLike = {
+  loaded: () => boolean;
+  isStyleLoaded: () => boolean;
+  getLayer: (id: string) => unknown;
+  jumpTo: (o: { center: [number, number]; zoom: number }) => void;
+  once: (ev: string, cb: () => void) => void;
+  queryRenderedFeatures: (
+    geom?: unknown,
+    opts?: { layers?: string[] }
+  ) => Array<{ properties: Record<string, unknown>; geometry: { type: string; coordinates: unknown } }>;
+  project: (lngLat: [number, number]) => { x: number; y: number };
+  getCanvas: () => HTMLCanvasElement;
+  getCanvasContainer: () => HTMLElement;
+};
+
+declare global {
+  interface Window {
+    mapboxMap?: MapboxLike;
+  }
+}
+
+test('LandIQ crop field popup uses aggregate totals + collapsible sections (issue #153)', async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+
+  await page.goto('http://localhost:3100/');
+
+  // Wait for the map + feedstock layer to be registered in the style.
+  await page.waitForFunction(
+    () => !!window.mapboxMap && !!window.mapboxMap.getLayer('feedstock-vector-layer'),
+    { timeout: 60_000 }
+  );
+
+  // Drive the map to an almond field and dispatch a click on it. Returns diagnostics.
+  const result = await page.evaluate(async () => {
+    const map = window.mapboxMap!;
+    const idle = () => new Promise<void>((r) => map.once('idle', () => r()));
+
+    // Almond-dense centers across the San Joaquin Valley (Modesto/Merced/Madera/Fresno).
+    const centers: Array<[number, number]> = [
+      [-120.85, 37.5],
+      [-120.45, 37.1],
+      [-120.2, 36.95],
+      [-119.95, 36.75],
+      [-121.0, 37.65],
+    ];
+
+    const isAlmond = (props: Record<string, unknown>) => {
+      const crop = String(props.main_crop_name ?? '').toLowerCase();
+      const resources = String(props.resources ?? '').toLowerCase();
+      return crop.includes('almond') || resources.includes('almond');
+    };
+
+    const centroidOf = (geom: { type: string; coordinates: any }): [number, number] | null => {
+      let ring: number[][] | null = null;
+      if (geom.type === 'Polygon') ring = geom.coordinates[0];
+      else if (geom.type === 'MultiPolygon') ring = geom.coordinates[0][0];
+      if (!ring || !ring.length) return null;
+      let x = 0,
+        y = 0;
+      for (const c of ring) {
+        x += c[0];
+        y += c[1];
+      }
+      return [x / ring.length, y / ring.length];
+    };
+
+    for (const center of centers) {
+      map.jumpTo({ center, zoom: 13 });
+      await idle();
+      const feats = map.queryRenderedFeatures(undefined, { layers: ['feedstock-vector-layer'] });
+      const almond = feats.find((f) => isAlmond(f.properties));
+      if (!almond) continue;
+
+      const centroid = centroidOf(almond.geometry as any);
+      if (!centroid) continue;
+      const p = map.project(centroid);
+      const rect = map.getCanvas().getBoundingClientRect();
+      const clientX = rect.left + p.x;
+      const clientY = rect.top + p.y;
+      const target = map.getCanvasContainer();
+      for (const type of ['mousedown', 'mouseup', 'click']) {
+        target.dispatchEvent(
+          new MouseEvent(type, { bubbles: true, cancelable: true, clientX, clientY, button: 0 })
+        );
+      }
+      return {
+        clicked: true,
+        cropName: String(almond.properties.main_crop_name ?? ''),
+        resources: String(almond.properties.resources ?? ''),
+        renderedCount: feats.length,
+      };
+    }
+    return { clicked: false };
+  });
+
+  expect(result.clicked, 'should have found and clicked an almond feedstock field').toBe(true);
+
+  // The popup must appear.
+  const popup = page.locator('.mapboxgl-popup-content');
+  await expect(popup).toBeVisible({ timeout: 15_000 });
+
+  const popupText = (await popup.innerText()).toLowerCase();
+
+  // Aggregate totals are visible WITHOUT expanding anything.
+  await expect(popup).toContainText('Annual Crop Residue Estimates');
+  expect(popupText).toContain('total wet');
+  expect(popupText).toContain('total dry');
+
+  // A collapsible <details> "Residue breakdown" section exists.
+  const detailsCount = await popup.locator('details').count();
+  expect(detailsCount, 'popup should contain at least one collapsible <details> section').toBeGreaterThan(0);
+
+  const breakdown = popup.locator('details', { hasText: 'Residue breakdown' });
+  await expect(breakdown).toHaveCount(1);
+
+  // The breakdown is collapsed by default (not open).
+  const openByDefault = await breakdown.evaluate((el) => (el as HTMLDetailsElement).open);
+  expect(openByDefault, 'residue breakdown should be collapsed by default').toBe(false);
+
+  // Evidence: compact, collapsed popup.
+  const collapsedBox = await popup.boundingBox();
+  await popup.screenshot({ path: 'e2e/__artifacts__/feedstock-popup-153-collapsed.png' });
+
+  // Expanding it reveals MULTIPLE residue streams for almonds (hulls/shells/prunings...).
+  await breakdown.locator('summary').click();
+  await expect(breakdown).toContainText(/wet:/i);
+  const wetRows = await breakdown.locator(':scope :text("Wet:")').count();
+  // Almonds have several residue resources; at least 2 distinct streams expected.
+  expect(wetRows, 'almond residue breakdown should list multiple residue types').toBeGreaterThanOrEqual(2);
+
+  // Evidence: expanded popup showing the multiple almond residue types.
+  await popup.screenshot({ path: 'e2e/__artifacts__/feedstock-popup-153-expanded.png' });
+
+  // Sanity: collapsed popup is reasonably short (not a mile tall).
+  expect(collapsedBox, 'popup should have a measurable box').not.toBeNull();
+  expect(collapsedBox!.height, 'collapsed popup should be compact (< 320px tall)').toBeLessThan(320);
+});

--- a/playwright.local.config.ts
+++ b/playwright.local.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Local-only config: targets a dev server already running on :3100 (port 3000 is held
+// by the Conductor oauth-proxy in this environment). Used for manual/agent verification
+// of the feedstock popup; CI uses playwright.config.ts.
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  retries: 0,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://localhost:3100',
+    trace: 'off',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'echo "reusing existing server on :3100"',
+    url: 'http://localhost:3100',
+    reuseExistingServer: true,
+    timeout: 5_000,
+  },
+});

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -2713,6 +2713,8 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
 
             // Calculate residue yields. Resources-first: use the polygon's own
             // residue names when present, else fall back to the crop-name chain.
+            // The popup is built as a raw HTML string (not React), so collapsible
+            // sections use native <details>/<summary> — no JS, neat nesting.
             let residueSection = '';
             const featureResources = parseFeatureResources(properties);
             const residueResult =
@@ -2722,15 +2724,10 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             const residueFactorsArray = residueResult?.factors;
 
             if (residueFactorsArray && residueFactorsArray.length > 0) {
-              // Add residue information to the popup
-              residueSection = `
-                <div style="margin-top: 10px; padding-top: 10px; border-top: 1px solid #eaeaea;">
-                  <h5 style="font-size: 0.95em; font-weight: bold; margin: 0 0 5px 0;">Annual Crop Residue Estimates</h5>
-              `;
-
-              // Calculate totals for summary
+              // Accumulate aggregate totals and per-resource detail rows in one pass.
               let totalWet = 0;
               let totalDry = 0;
+              let breakdownRows = '';
 
               residueFactorsArray.forEach((factor, index) => {
                 const dryYield = Math.round(acres * factor.dryTonsPerAcre);
@@ -2739,13 +2736,13 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
                 totalDry += dryYield;
 
                 const name = factor.resourceName || factor.residueType || 'Residue';
-                
+
                 // Add separator between multiple streams
                 if (index > 0) {
-                  residueSection += `<div style="height: 1px; background-color: #f0f0f0; margin: 5px 0;"></div>`;
+                  breakdownRows += `<div style="height: 1px; background-color: #f0f0f0; margin: 5px 0;"></div>`;
                 }
 
-                residueSection += `
+                breakdownRows += `
                   <div style="margin-bottom: 2px; margin-top: 2px;">
                     <div style="font-weight: bold; font-size: 0.9em; color: #555;">${name}</div>
                     <div style="padding-left: 8px;">
@@ -2756,17 +2753,28 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
                 `;
               });
 
-              // Add totals if there are multiple streams
-              if (residueFactorsArray.length > 1) {
-                 residueSection += `
-                  <div style="margin-top: 8px; pt-2; border-top: 1px dashed #ccc; font-weight: bold;">
-                    <div style="margin-bottom: 3px; text-align: left;">Total Wet: ${formatNumberWithCommas(totalWet)} tons/year</div>
-                    <div style="margin-bottom: 3px; text-align: left;">Total Dry: ${formatNumberWithCommas(totalDry)} tons/year</div>
-                  </div>
-                `;
-              }
+              const typeCount = residueFactorsArray.length;
+              const typeLabel = `${typeCount} residue type${typeCount === 1 ? '' : 's'}`;
 
-              residueSection += `</div>`;
+              // Always-visible aggregate summary (collapsed view): totals up top.
+              residueSection = `
+                <div style="margin-top: 10px; padding-top: 10px; border-top: 1px solid #eaeaea;">
+                  <h5 style="font-size: 0.95em; font-weight: bold; margin: 0 0 5px 0;">Annual Crop Residue Estimates</h5>
+                  <div style="font-weight: bold;">
+                    <div style="margin-bottom: 2px; text-align: left;">Total Wet: ${formatNumberWithCommas(totalWet)} tons/year</div>
+                    <div style="margin-bottom: 2px; text-align: left;">Total Dry: ${formatNumberWithCommas(totalDry)} tons/year</div>
+                  </div>
+              `;
+
+              // Per-resource detail lives in a collapsed <details> so the popup
+              // stays compact even for multi-residue crops like almonds.
+              residueSection += `
+                  <details style="margin-top: 6px;">
+                    <summary style="cursor: pointer; font-size: 0.85em; font-weight: bold; color: #2b6cb0; outline: none;">Residue breakdown (${typeLabel})</summary>
+                    <div style="padding: 4px 0 0 8px;">${breakdownRows}</div>
+                  </details>
+                </div>
+              `;
             }
 
             // --- Derive geoid and resource name for API calls ---
@@ -2866,11 +2874,13 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
                   const apiSection = document.getElementById(apiSectionId);
                   if (apiSection) {
                     if (apiHTML) {
+                      // Collapsed by default so live composition/seasonal/USDA data
+                      // doesn't stretch the popup; expand to see the rolled-up values.
                       apiSection.innerHTML = `
-                        <div style="margin-top:10px;padding-top:10px;border-top:1px solid #eaeaea;">
-                          <h5 style="font-size:0.95em;font-weight:bold;margin:0 0 5px 0;">Live Feedstock Data</h5>
-                          <div style="font-size:0.85em;">${apiHTML}</div>
-                        </div>`;
+                        <details style="margin-top:10px;padding-top:10px;border-top:1px solid #eaeaea;">
+                          <summary style="cursor:pointer;font-size:0.9em;font-weight:bold;color:#2b6cb0;outline:none;">Composition &amp; seasonal data</summary>
+                          <div style="font-size:0.85em;padding:4px 0 0 8px;">${apiHTML}</div>
+                        </details>`;
                     } else {
                       apiSection.innerHTML = '';
                     }


### PR DESCRIPTION
## Summary

Fixes #153 — the LandIQ **"Crop Field Details"** map popup was a mile tall for multi-residue crops (almonds have 6 residue streams), overflowing the viewport.

The popup is a raw HTML string inside `mapboxgl.Popup` (not React), so this uses native `<details>`/`<summary>` for collapsible sections — no JS, neat nesting.

### What changed (`src/components/Map.js`)
- **Aggregate up top, always visible:** `Total Wet` / `Total Dry` tons/year now render for every field (previously only for >1 stream).
- **Per-resource residue detail** moved into a `<details>` titled `Residue breakdown (N residue types)`, collapsed by default.
- **Live composition/seasonal/USDA data** (`getAvailability` + `getAnalysisByResource` + `getCensusByCrop` — the aggregated per-resource `.../parameters` endpoints) moved into a `Composition & seasonal data` `<details>`, collapsed by default.

### Verification
- `npm run build` ✓ (compiled, TypeScript clean)
- New Playwright regression test `e2e/tests/feedstock-popup.spec.ts` ✓ — drives the real map, clicks an **almond** field, asserts aggregate totals are visible, the residue breakdown is a collapsed `<details>` with ≥2 streams, and the collapsed popup is < 320px tall.
- Verified live in a real Chromium browser: collapsed popup shows `Almonds / Total Wet 246 / Total Dry 150 / ▶ Residue breakdown (6 residue types) / ▶ Composition & seasonal data`; expanding lists all 6 almond residue types.

> Note: the Claude-in-Chrome MCP browser environment redirects `localhost`→`staging` (stale PWA/host policy), so verification was done with Playwright in a fresh isolated Chromium against the local dev server instead.

closes #153
