### PR TITLE
fix(map): split CARB quantities by byproduct and append units (#157)

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -346,9 +346,42 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
       const labelKeys = Object.keys(labels);
 
       if (labelKeys.length > 0) {
+        const isCarbPopup = layerId === CARB_POPUP_LABEL_KEY;
+        const carbQtyRaw = isCarbPopup ? properties.quantities : null;
+        const carbByproductsRaw = isCarbPopup ? properties.byproducts : null;
+        const hasCarbQty = carbQtyRaw != null && !nullValues.includes(String(carbQtyRaw).trim());
+        const hasCarbByproducts = carbByproductsRaw != null && !nullValues.includes(String(carbByproductsRaw).trim());
+
         labelKeys.forEach(key => {
           if (Object.prototype.hasOwnProperty.call(properties, key) &&
               !nullValues.includes(String(properties[key]).trim())) {
+
+            // CARB: absorb byproducts into the quantities section below
+            if (isCarbPopup && key === 'byproducts' && hasCarbQty) {
+              return;
+            }
+
+            // CARB: render quantities as a correlated list paired with byproduct names
+            if (isCarbPopup && key === 'quantities') {
+              const qtyParts = String(carbQtyRaw).split(', ').map(s => s.trim()).filter(Boolean);
+              const byproductParts = hasCarbByproducts
+                ? String(carbByproductsRaw).split(', ').map(s => s.trim()).filter(Boolean)
+                : [];
+
+              if (byproductParts.length > 0 && byproductParts.length === qtyParts.length) {
+                const itemLines = byproductParts.map((item, i) => {
+                  const num = Number(qtyParts[i].replace(/,/g, ''));
+                  const formattedQty = !isNaN(num) ? num.toLocaleString() : qtyParts[i];
+                  return `<div style="margin-left: 12px; margin-bottom: 2px; text-align: left;">- ${item}: ${formattedQty} tons per year</div>`;
+                }).join('');
+                content += `<div style="margin-bottom: 3px; text-align: left;"><strong style="font-weight: bold;">Reported Quantities:</strong>${itemLines}</div>`;
+              } else {
+                // Fallback: lengths mismatch or no byproducts — show as-is with units
+                content += `<div style="margin-bottom: 3px; text-align: left;"><strong style="font-weight: bold;">Reported Quantities:</strong> ${carbQtyRaw} tons per year</div>`;
+              }
+              return;
+            }
+
             content += formatAndBuildLine(key, properties[key]);
           }
         });


### PR DESCRIPTION
## Summary
- Zips the comma-space-delimited `byproducts` and `quantities` strings into labeled line items (e.g. `- Grain feed: 3,272 tons per year`) instead of rendering one confusing concatenated string
- Split uses `, ` (comma+space) so thousands-separator commas inside a single number (e.g. `37,289`) are preserved
- Hides the standalone Byproducts field when it has been absorbed into the Reported Quantities section
- Fallback renders the raw quantities string with ' tons per year' when lengths mismatch or byproducts is absent

Closes #157

## Test plan
- [ ] Click a multi-byproduct CARB processor (e.g. Corn → Valley Grain/Azteca Milling) and confirm popup shows each byproduct on its own line with its quantity and 'tons per year'
- [ ] Confirm thousands-separator numbers like `37,289` stay intact (not split)
- [ ] Click a single-byproduct processor and confirm single-line fallback works
- [ ] Click a processor with no quantities field and confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)