### PR TITLE
fix(map): hide zero rows, round quantities, capitalize byproduct names in CARB popup

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -371,9 +371,13 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
               if (byproductParts.length > 0 && byproductParts.length === qtyParts.length) {
                 const itemLines = byproductParts.map((item, i) => {
                   const num = Number(qtyParts[i].replace(/,/g, ''));
-                  const formattedQty = !isNaN(num) ? num.toLocaleString() : qtyParts[i];
+                  if (isNaN(num) || num === 0) return null;
+                  const formattedQty = num >= 1
+                    ? Math.round(num).toLocaleString()
+                    : num.toFixed(2);
                   return `<div style="margin-left: 12px; margin-bottom: 2px; text-align: left;">- ${item}: ${formattedQty} tons per year</div>`;
-                }).join('');
+                }).filter(Boolean).join('');
+                if (!itemLines) return;
                 content += `<div style="margin-bottom: 3px; text-align: left;"><strong style="font-weight: bold;">Reported Quantities:</strong>${itemLines}</div>`;
               } else {
                 // Fallback: lengths mismatch or no byproducts — show as-is with units

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -375,7 +375,8 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
                   const formattedQty = num >= 1
                     ? Math.round(num).toLocaleString()
                     : num.toFixed(2);
-                  return `<div style="margin-left: 12px; margin-bottom: 2px; text-align: left;">- ${item}: ${formattedQty} tons per year</div>`;
+                  const displayItem = item.charAt(0).toUpperCase() + item.slice(1);
+                  return `<div style="margin-left: 12px; margin-bottom: 2px; text-align: left;">- ${displayItem}: ${formattedQty} tons per year</div>`;
                 }).filter(Boolean).join('');
                 if (!itemLines) return;
                 content += `<div style="margin-bottom: 3px; text-align: left;"><strong style="font-weight: bold;">Reported Quantities:</strong>${itemLines}</div>`;


### PR DESCRIPTION
## Summary
Three polish fixes on top of PR #158 (merged):
- **Hide zero-value rows** — e.g. 'Peels: 0 tons per year' no longer shown
- **Round quantities** — values ≥ 1 ton rounded to nearest whole number (1,090.154 → 1,090); values < 1 ton shown to 2 decimal places
- **Sentence-case names** — byproduct names capitalize first letter ('gluten feed' → 'Gluten feed', 'germ meal' → 'Germ meal'; all-caps abbreviations like 'CFE' unchanged)

## Test plan
- [ ] CAMPBELL SOUP (Tomatoes): Peels row hidden, Hulls and Pomace show whole-ton numbers
- [ ] VALLEY GRAIN/AZTECA MILLING (Corn): 4 rows, names capitalized, whole-ton numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)