### PR TITLE
fix(residues): filter popups and inventory by Include In Totals + Collected (#164)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -940,16 +940,18 @@ Async loader for the live `resource_info.json` from GitHub Pages.
 
 **Data source:** `https://sustainability-software-lab.github.io/ca-biositing/resource_info.json`
 
-**Raw JSON fields per record:** `resource`, `resource_code`, `landiq_crop_name`, `residue_type`, `collected`, `from_month`, `to_month`, `residue_yield_wet_ton_per_ac`, `moisture_content`, `residue_yield_dry_ton_per_ac`
+**Raw JSON fields per record (GOTCHA — Title Case headers):** the published JSON uses Title Case column headers, not snake_case: `Resource`, `Resource Code`, `LandIQ Crop Name`, `Residue Type`, `Collected?`, `Include In Totals`, `From Month`, `To Month`, `Residue Yield (Wet Ton/Ac)`, `Moisture Content`, `Residue Yield (Dry Ton/Ac)` (a side-car `resource_info_header_mapping.json` documents the snake_case↔Title Case mapping). `Collected?` and `Include In Totals` are real JSON booleans (legacy was `"TRUE"`/`"FALSE"` strings). `parseResidueRecords` reads **both** conventions via a `pickField` helper, so reading only snake_case (the historical bug fixed in #164) silently drops every field. When adding/renaming a JSON column, update the `pickField` calls in `residue-data.ts`.
 
 **Exports:**
 
 | Export | Description |
 |---|---|
-| `fetchResidueData()` | Fetches and caches the JSON. Idempotent. |
+| `fetchResidueData()` | Fetches and caches the JSON. Idempotent. Delegates parsing to `parseResidueRecords`. |
+| `parseResidueRecords(rawArray)` | Pure parser → `{ byCrop, byResource }`. Reads Title Case and legacy snake_case headers. Exported for unit testing. |
 | `getResidueData(standardizedCropName)` | Returns `ResidueFactors[]` for a crop (empty array if not found). Synchronous after load. |
+| `shouldIncludeResidueInTotals(factor)` | **Shared dedup filter** for popup + inventory: `includeInTotals === true && collected === false`. Excludes overlapping sub-categories (`Include In Totals = false`, e.g. "Almond Shells and Hulls mix") and processing waste (`Collected? = true`, e.g. hulls/shells) so field totals are not double-counted. Both `Map.js` popups and `SitingInventory.tsx` call this single predicate so they cannot diverge. |
 | `onResidueDataLoaded(callback)` | Subscribe to load completion. Fires immediately if already loaded. |
-| `ResidueFactors` | `{ resourceName, wetTonsPerAcre, moistureContent, dryTonsPerAcre, seasonalAvailability, fromMonth?, toMonth?, residueType, collected, category? }` |
+| `ResidueFactors` | `{ resourceName, wetTonsPerAcre, moistureContent, dryTonsPerAcre, seasonalAvailability, fromMonth?, toMonth?, residueType, collected, includeInTotals?, category? }` |
 
 ---
 

--- a/e2e/tests/feedstock-popup.spec.ts
+++ b/e2e/tests/feedstock-popup.spec.ts
@@ -144,6 +144,14 @@ test('LandIQ crop field popup uses aggregate totals + collapsible sections (issu
   // Evidence: expanded popup showing the multiple almond residue types.
   await popup.screenshot({ path: 'e2e/__artifacts__/feedstock-popup-153-expanded.png' });
 
+  // Regression for issue #164: overlapping sub-categories flagged Include In Totals = false
+  // (e.g. the "Almond Shells and Hulls mix" combo and "Almond stick char") and collected
+  // processing waste must NOT appear in the field popup breakdown, so totals are not
+  // double-counted.
+  const breakdownText = (await breakdown.innerText()).toLowerCase();
+  expect(breakdownText).not.toContain('shells and hulls mix');
+  expect(breakdownText).not.toContain('stick char');
+
   // Sanity: collapsed popup is reasonably short (not a mile tall).
   expect(collapsedBox, 'popup should have a measurable box').not.toBeNull();
   expect(collapsedBox!.height, 'collapsed popup should be compact (< 320px tall)').toBeLessThan(320);

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -15,7 +15,7 @@ import { getAvailability, getAnalysisByResource, getCensusByCrop } from '@/lib/a
 import { getCountyGeoid } from '@/lib/county-lookup';
 import { getApiResource, getUsdaCropName, STATE_GEOID } from '@/lib/resource-mapping';
 import { parseFeatureResources, getResidueFactorsByResourceNames } from '@/lib/resource-residues';
-import { onResidueDataLoaded } from '@/lib/residue-data';
+import { onResidueDataLoaded, shouldIncludeResidueInTotals } from '@/lib/residue-data';
 import { getCountyAggregateStats } from '@/lib/county-analysis';
 import { formatNumberWithCommas } from '@/lib/utils';
 
@@ -2764,7 +2764,10 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
               (featureResources.length > 0
                 ? getResidueFactorsByResourceNames(featureResources)
                 : null) ?? getCropResidueFactors(cropName);
-            const residueFactorsArray = residueResult?.factors;
+            // Shared dedup filter: only residues flagged Include In Totals and
+            // left in the field (Collected? = false) count toward the popup
+            // totals, so overlapping sub-categories are not double-counted.
+            const residueFactorsArray = residueResult?.factors?.filter(shouldIncludeResidueInTotals);
 
             if (residueFactorsArray && residueFactorsArray.length > 0) {
               // Accumulate aggregate totals and per-resource detail rows in one pass.

--- a/src/components/SitingInventory.tsx
+++ b/src/components/SitingInventory.tsx
@@ -9,7 +9,7 @@ import { formatNumberWithCommas, downloadCSV } from '@/lib/utils';
 import { getAvailability, getAnalysisByResource } from '@/lib/api';
 import { getApiResource, STATE_GEOID } from '@/lib/resource-mapping';
 import { getResidueFactorsByResourceNames } from '@/lib/resource-residues';
-import { onResidueDataLoaded } from '@/lib/residue-data';
+import { onResidueDataLoaded, shouldIncludeResidueInTotals } from '@/lib/residue-data';
 import { computeEnergyTotals, EnergyTotals } from '@/lib/energy-calculations';
 import { CompositionData, parseCompositionData, CompositionFilters, CompositionLookup, cropPassesCompositionFilters } from '@/lib/composition-filters';
 import { computeMixSummary, rankTechnologies, TechScore } from '@/lib/technology-matcher';
@@ -188,9 +188,10 @@ const SitingInventory: React.FC<SitingInventoryProps> = ({
       for (const factor of residueResult.factors) {
         // Skip entries with no yield data (e.g. "Missing" values that parsed to 0)
         if (!factor.dryTonsPerAcre && !factor.wetTonsPerAcre) continue;
-        // Exclude processor waste (collected===true means hulls, shells, etc. removed
-        // at a processing facility -- not attributable to field acreage).
-        if (factor.collected) continue;
+        // Shared dedup filter: keep only residues flagged Include In Totals and
+        // left in the field (Collected? = false). Excludes overlapping
+        // sub-categories and processor waste so totals are not double-counted.
+        if (!shouldIncludeResidueInTotals(factor)) continue;
         // Resources-tier rows key composition off the residue's own name;
         // crop-tier rows fall back to the crop's primary resource.
         const apiResource = perResidue

--- a/src/lib/residue-data.ts
+++ b/src/lib/residue-data.ts
@@ -30,6 +30,12 @@ export interface ResidueFactors {
   toMonth?: number;
   residueType: string; // e.g. "Ag Residue"
   collected: boolean; // e.g. TRUE/FALSE
+  /**
+   * Data-team dedup flag ("Include In Totals"): false marks an overlapping
+   * sub-category (e.g. "Almond Shells and Hulls mix") that must not be summed
+   * into popup/inventory totals. Undefined is treated as excluded.
+   */
+  includeInTotals?: boolean;
   category?: string;
 }
 
@@ -130,6 +136,106 @@ const inferCategory = (item: RawResidueData): string => {
 };
 
 
+/** Read the first present key from a record, supporting both the live JSON's
+ *  Title Case headers (e.g. "LandIQ Crop Name") and the legacy snake_case keys
+ *  (e.g. "landiq_crop_name"). The published resource_info.json switched to Title
+ *  Case headers (see resource_info_header_mapping.json), so reading only one
+ *  naming convention silently drops every field. */
+function pickField(item: Record<string, unknown>, ...keys: string[]): unknown {
+  for (const key of keys) {
+    const value = item[key];
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+}
+
+/** Parse a TRUE/FALSE flag that may arrive as a real JSON boolean (live JSON) or
+ *  a "TRUE"/"FALSE" string (legacy JSON). Missing/unparseable → false. */
+function parseFlag(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') return value.trim().toUpperCase() === 'TRUE';
+  return false;
+}
+
+function toStr(value: unknown): string {
+  return value === undefined || value === null ? '' : String(value);
+}
+
+/**
+ * Shared inclusion filter for field-attributable residue totals.
+ *
+ * A residue counts toward map-popup and inventory totals only when the data team
+ * has flagged it `Include In Totals` (the dedup flag that excludes overlapping
+ * sub-categories like "Almond Shells and Hulls mix") AND it is left in the field
+ * rather than collected at a processing facility (`Collected? = false`) — the
+ * field popup/inventory attributes tonnage to crop acreage, so processing waste
+ * (hulls, shells; null per-acre yield) does not belong. Both the popup and the
+ * inventory call this single predicate so they can never diverge.
+ */
+export function shouldIncludeResidueInTotals(
+  factor: Pick<ResidueFactors, 'includeInTotals' | 'collected'>
+): boolean {
+  return factor.includeInTotals === true && factor.collected === false;
+}
+
+/**
+ * Pure parser for the raw resource_info.json array. Reads both Title Case and
+ * legacy snake_case headers. Returns the crop-keyed and resource-keyed indexes.
+ * Exported for unit testing; `fetchResidueData` wires it to the network fetch.
+ */
+export function parseResidueRecords(
+  data: Array<Record<string, unknown>>
+): { byCrop: Record<string, ResidueFactors[]>; byResource: Record<string, ResidueFactors> } {
+  const byCrop: Record<string, ResidueFactors[]> = {};
+  const byResource: Record<string, ResidueFactors> = {};
+
+  data.forEach(item => {
+    const cropName = toStr(pickField(item, 'LandIQ Crop Name', 'landiq_crop_name')).trim();
+    if (!cropName) return;
+
+    const resource = toStr(pickField(item, 'Resource', 'resource'));
+
+    const wetTons = parseFloat(toStr(pickField(item, 'Residue Yield (Wet Ton/Ac)', 'residue_yield_wet_ton_per_ac'))) || 0;
+    const dryTons = parseFloat(toStr(pickField(item, 'Residue Yield (Dry Ton/Ac)', 'residue_yield_dry_ton_per_ac'))) || 0;
+
+    // Parse moisture content "11%" -> 0.11
+    let moisture = 0;
+    const moistureStr = toStr(pickField(item, 'Moisture Content', 'moisture_content')).replace('%', '');
+    if (moistureStr) {
+      moisture = parseFloat(moistureStr) / 100;
+      if (Number.isNaN(moisture)) moisture = 0;
+    }
+
+    const fromMonthStr = toStr(pickField(item, 'From Month', 'from_month'));
+    const toMonthStr = toStr(pickField(item, 'To Month', 'to_month'));
+    const seasonal = parseSeasonalAvailability(fromMonthStr, toMonthStr);
+    const fromMonthNum = parseInt(fromMonthStr, 10);
+    const toMonthNum = parseInt(toMonthStr, 10);
+
+    const factor: ResidueFactors = {
+      resourceName: resource,
+      wetTonsPerAcre: wetTons,
+      dryTonsPerAcre: dryTons,
+      moistureContent: moisture,
+      seasonalAvailability: seasonal,
+      fromMonth: isNaN(fromMonthNum) ? undefined : fromMonthNum,
+      toMonth: isNaN(toMonthNum) ? undefined : toMonthNum,
+      residueType: toStr(pickField(item, 'Residue Type', 'residue_type')),
+      collected: parseFlag(pickField(item, 'Collected?', 'collected')),
+      includeInTotals: parseFlag(pickField(item, 'Include In Totals', 'include_in_totals')),
+    };
+
+    (byCrop[cropName] ??= []).push(factor);
+
+    const resourceKey = resource.trim().toLowerCase();
+    if (resourceKey) {
+      byResource[resourceKey] = factor;
+    }
+  });
+
+  return { byCrop, byResource };
+}
+
 export const fetchResidueData = async (): Promise<void> => {
   if (isDataLoaded) return;
   if (loadPromise) return loadPromise;
@@ -140,63 +246,13 @@ export const fetchResidueData = async (): Promise<void> => {
       if (!response.ok) {
         throw new Error(`Failed to fetch residue data: ${response.statusText}`);
       }
-      const data: RawResidueData[] = await response.json();
-      
-      // Process the data
-      const newProcessedData: Record<string, ResidueFactors[]> = {};
-      const newByResource: Record<string, ResidueFactors> = {};
+      const data: unknown = await response.json();
+      const records = Array.isArray(data) ? (data as Array<Record<string, unknown>>) : [];
 
-      data.forEach(item => {
-        let cropName = item.landiq_crop_name; // This seems to be the key we want to match
-        if (!cropName) return;
-        
-        // Normalize crop name (trim whitespace)
-        cropName = cropName.trim();
+      const { byCrop, byResource } = parseResidueRecords(records);
 
-        // Parse numeric values
-        const wetTons = parseFloat(item.residue_yield_wet_ton_per_ac) || 0;
-        const dryTons = parseFloat(item.residue_yield_dry_ton_per_ac) || 0;
-        
-        // Parse moisture content "11%" -> 0.11
-        let moisture = 0;
-        const moistureStr = item.moisture_content?.replace('%', '');
-        if (moistureStr) {
-          moisture = parseFloat(moistureStr) / 100;
-        }
-
-        const seasonal = parseSeasonalAvailability(item.from_month, item.to_month);
-        
-        const collected = item.collected?.toUpperCase() === 'TRUE';
-
-        const fromMonthNum = parseInt(item.from_month, 10);
-        const toMonthNum   = parseInt(item.to_month,   10);
-
-        const factor: ResidueFactors = {
-          resourceName: item.resource,
-          wetTonsPerAcre: wetTons,
-          dryTonsPerAcre: dryTons,
-          moistureContent: moisture,
-          seasonalAvailability: seasonal,
-          fromMonth: isNaN(fromMonthNum) ? undefined : fromMonthNum,
-          toMonth:   isNaN(toMonthNum)   ? undefined : toMonthNum,
-          residueType: item.residue_type,
-          collected: collected
-          // category: inferCategory(item) // We will handle category assignment when retrieving
-        };
-        
-        if (!newProcessedData[cropName]) {
-          newProcessedData[cropName] = [];
-        }
-        newProcessedData[cropName].push(factor);
-
-        const resourceKey = item.resource?.trim().toLowerCase();
-        if (resourceKey) {
-          newByResource[resourceKey] = factor;
-        }
-      });
-
-      processedResidueData = newProcessedData;
-      processedResidueByResource = newByResource;
+      processedResidueData = byCrop;
+      processedResidueByResource = byResource;
       isDataLoaded = true;
       onLoadedCallbacks.forEach(cb => cb());
       onLoadedCallbacks = [];

--- a/src/lib/residue-fallbacks.ts
+++ b/src/lib/residue-fallbacks.ts
@@ -43,6 +43,7 @@ function factor(
   fromMonth: number,
   toMonth: number,
   collected = false,
+  includeInTotals = true,
 ): ResidueFactors {
   return {
     resourceName,
@@ -54,6 +55,7 @@ function factor(
     fromMonth,
     toMonth,
     collected,
+    includeInTotals,
   };
 }
 

--- a/tests/residue-data.test.ts
+++ b/tests/residue-data.test.ts
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseResidueRecords,
+  shouldIncludeResidueInTotals,
+} from '../src/lib/residue-data';
+import type { ResidueFactors } from '../src/lib/residue-data';
+
+// A record shaped like the live GitHub Pages resource_info.json (Title Case headers,
+// real JSON booleans for the flags, string yields).
+function liveAlmondRecords(): Array<Record<string, unknown>> {
+  return [
+    { 'Residue Type': 'Ag Residue', 'Resource': 'Almond Branches', 'LandIQ Crop Name': 'Almonds',
+      'Include In Totals': true, 'Collected?': false, 'From Month': '11', 'To Month': '2',
+      'Residue Yield (Wet Ton/Ac)': '1.7', 'Moisture Content': '15%', 'Residue Yield (Dry Ton/Ac)': '1.5' },
+    { 'Residue Type': 'Processing Waste', 'Resource': 'Almond Hulls', 'LandIQ Crop Name': 'Almonds ',
+      'Include In Totals': true, 'Collected?': true, 'From Month': '8', 'To Month': '10',
+      'Residue Yield (Wet Ton/Ac)': null, 'Moisture Content': '', 'Residue Yield (Dry Ton/Ac)': null },
+    { 'Residue Type': 'Processing Waste', 'Resource': 'Almond Shells and Hulls mix', 'LandIQ Crop Name': 'Almonds',
+      'Include In Totals': false, 'Collected?': true, 'From Month': '8', 'To Month': '10',
+      'Residue Yield (Wet Ton/Ac)': null, 'Moisture Content': '', 'Residue Yield (Dry Ton/Ac)': null },
+  ];
+}
+
+test('parseResidueRecords reads Title Case headers from the live JSON shape', () => {
+  const { byCrop, byResource } = parseResidueRecords(liveAlmondRecords());
+
+  // Crop names are trimmed, so the trailing-space "Almonds " merges with "Almonds".
+  assert.ok(byCrop['Almonds'], 'expected an "Almonds" crop entry');
+  assert.equal(byCrop['Almonds'].length, 3);
+
+  const branches = byResource['almond branches'];
+  assert.ok(branches, 'expected the resource index keyed by lowercased resource name');
+  assert.equal(branches.resourceName, 'Almond Branches');
+  assert.equal(branches.dryTonsPerAcre, 1.5);
+  assert.equal(branches.wetTonsPerAcre, 1.7);
+  assert.equal(branches.moistureContent, 0.15);
+  assert.equal(branches.residueType, 'Ag Residue');
+  assert.equal(branches.collected, false);
+  assert.equal(branches.includeInTotals, true);
+  assert.equal(branches.fromMonth, 11);
+  assert.equal(branches.toMonth, 2);
+});
+
+test('parseResidueRecords still reads legacy snake_case keys (back-compat)', () => {
+  const { byResource } = parseResidueRecords([
+    { resource: 'Rice straw', landiq_crop_name: 'Rice (R1)', residue_type: 'Ag Residue',
+      collected: 'FALSE', include_in_totals: 'TRUE', from_month: '9', to_month: '11',
+      residue_yield_wet_ton_per_ac: '2.0', moisture_content: '25%', residue_yield_dry_ton_per_ac: '1.5' },
+  ]);
+  const straw = byResource['rice straw'];
+  assert.ok(straw);
+  assert.equal(straw.dryTonsPerAcre, 1.5);
+  assert.equal(straw.collected, false);
+  assert.equal(straw.includeInTotals, true);
+});
+
+test('parseResidueRecords parses include_in_totals from boolean and "TRUE", missing → false', () => {
+  const { byResource } = parseResidueRecords([
+    { 'Resource': 'A', 'LandIQ Crop Name': 'Crop A', 'Include In Totals': true, 'Collected?': false,
+      'Residue Yield (Dry Ton/Ac)': '1', 'Residue Yield (Wet Ton/Ac)': '1', 'From Month': '1', 'To Month': '2' },
+    { 'Resource': 'B', 'LandIQ Crop Name': 'Crop B', 'Include In Totals': false, 'Collected?': false,
+      'Residue Yield (Dry Ton/Ac)': '1', 'Residue Yield (Wet Ton/Ac)': '1', 'From Month': '1', 'To Month': '2' },
+    // No Include In Totals key at all → must default to false (excluded).
+    { 'Resource': 'C', 'LandIQ Crop Name': 'Crop C', 'Collected?': false,
+      'Residue Yield (Dry Ton/Ac)': '1', 'Residue Yield (Wet Ton/Ac)': '1', 'From Month': '1', 'To Month': '2' },
+  ]);
+  assert.equal(byResource['a'].includeInTotals, true);
+  assert.equal(byResource['b'].includeInTotals, false);
+  assert.equal(byResource['c'].includeInTotals, false);
+});
+
+function factor(overrides: Partial<ResidueFactors>): ResidueFactors {
+  return {
+    resourceName: 'x',
+    wetTonsPerAcre: 1,
+    dryTonsPerAcre: 1,
+    moistureContent: 0.1,
+    seasonalAvailability: {},
+    residueType: 'Ag Residue',
+    collected: false,
+    includeInTotals: true,
+    ...overrides,
+  };
+}
+
+test('shouldIncludeResidueInTotals: true only when includeInTotals===true AND collected===false', () => {
+  assert.equal(shouldIncludeResidueInTotals(factor({})), true);
+  assert.equal(shouldIncludeResidueInTotals(factor({ includeInTotals: false })), false);
+  assert.equal(shouldIncludeResidueInTotals(factor({ collected: true })), false);
+  assert.equal(shouldIncludeResidueInTotals(factor({ includeInTotals: false, collected: true })), false);
+  // Missing/undefined flag (e.g. a record stripped of the key) is excluded.
+  assert.equal(shouldIncludeResidueInTotals(factor({ includeInTotals: undefined })), false);
+});
+
+test('almond records de-duplicate: included set drops the "mix" combo and collected hulls', () => {
+  const { byCrop } = parseResidueRecords(liveAlmondRecords());
+  const included = byCrop['Almonds'].filter(shouldIncludeResidueInTotals);
+  const names = included.map(f => f.resourceName);
+  assert.deepEqual(names, ['Almond Branches']);
+  // The overlapping "Shells and Hulls mix" (include=false) and collected hulls are excluded.
+  assert.ok(!names.includes('Almond Shells and Hulls mix'));
+  assert.ok(!names.includes('Almond Hulls'));
+});


### PR DESCRIPTION
## Summary

Filters the map crop-field pop-ups and the siting inventory so overlapping/duplicate residue feedstocks no longer double-count, using the data team's new `Include In Totals` flag combined with the existing `Collected?` column.

closes #164

## Root Causes

1. **Parser read the wrong keys.** `src/lib/residue-data.ts` parsed snake_case keys, but the published `resource_info.json` uses **Title Case** headers (`"LandIQ Crop Name"`, `"Collected?"`, `"Include In Totals"`). Every field read `undefined`, so the new flag was invisible (and residue data silently fell back). The parser now reads **both** conventions via a `pickField` helper.
2. **No dedup filter.** The Map.js popup summed *every* residue factor; `SitingInventory` filtered only `collected`. Neither applied `Include In Totals`.

## What Changed

- **`src/lib/residue-data.ts`** — added `includeInTotals` to `ResidueFactors`; extracted a pure, tested `parseResidueRecords()` reading Title Case + snake_case headers and the new boolean flag; exported a shared `shouldIncludeResidueInTotals(factor)` predicate (`includeInTotals === true && collected === false`).
- **`src/components/Map.js`** — crop-field popup filters residue factors through the shared predicate before summing/rendering.
- **`src/components/SitingInventory.tsx`** — replaced the `collected`-only skip with the shared predicate.
- **`src/lib/residue-fallbacks.ts`** — curated fallbacks default `includeInTotals = true` so they still count.
- **`AGENTS.md`** — documented the Title Case header gotcha, dual-case parsing, and the shared filter.

## Filter direction (data-grounded)

The field popup/inventory is acreage-based (`acres × tonsPerAcre`). In the live data, `Collected? = true` rows (hulls, shells) carry **null** per-acre yields (processing waste), while field residues (branches, stover, straw) are `Collected? = false`. So the correct, consistent rule is `includeInTotals === true && collected === false`. This drops "Almond Shells and Hulls mix" / "stick char" (inc=false) and "Corn stover stalks" (inc=false) while keeping "Corn stover whole" (inc=true).

## Verification

| Check | Result |
|---|---|
| New unit tests fail before fix (red) | 5 failed as expected |
| New unit tests pass after fix (green) | 6 passed |
| Full unit suite (`tsx --test tests/*.test.ts`) | 160 passed, 0 failed |
| Type check (`tsc --noEmit`) | clean |
| Build (`next build`) | success (TypeScript checked) |
| Playwright e2e | extended `feedstock-popup.spec.ts`; runs in the staging deploy (no Mapbox-enabled dev env locally) |

## QA / QC Checklist (Human Verification)

- [ ] Click an **Almonds** crop field on the map → "Annual Crop Residue Estimates" totals reflect only field residues (branches/woodchips); the breakdown no longer lists "Almond Shells and Hulls mix" or "stick char".
- [ ] Run a **siting analysis** over an almond/corn region → inventory rows do not double-count overlapping residues (no "Corn stover stalks" alongside "Corn stover whole").
- [ ] Totals (popup + inventory) are internally consistent (same filter applied to both).
- [ ] No regression for single-residue crops (e.g. Barley straw still shows).
- [ ] Residue data loads from GitHub Pages (console: "Residue data loaded successfully N items", N > 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
