### PR TITLE
fix(popup): per-resource composition summary + tolerate resource_info schema change

### DIFF
--- a/e2e/tests/feedstock-popup.spec.ts
+++ b/e2e/tests/feedstock-popup.spec.ts
@@ -35,6 +35,16 @@ test('LandIQ crop field popup uses aggregate totals + collapsible sections (issu
 }) => {
   test.setTimeout(120_000);
 
+  // The residue breakdown is built synchronously at click time from the async-loaded
+  // resource_info.json. Listen for its load signal BEFORE navigating so a fast click
+  // doesn't beat the data and silently drop the residue section (a real flake).
+  const residueDataReady = page
+    .waitForEvent('console', {
+      predicate: (m) => /Residue data loaded successfully/i.test(m.text()),
+      timeout: 60_000,
+    })
+    .catch(() => undefined);
+
   await page.goto('http://localhost:3100/');
 
   // Wait for the map + feedstock layer to be registered in the style.
@@ -42,6 +52,9 @@ test('LandIQ crop field popup uses aggregate totals + collapsible sections (issu
     () => !!window.mapboxMap && !!window.mapboxMap.getLayer('feedstock-vector-layer'),
     { timeout: 60_000 }
   );
+
+  // ...and for residue factor data to be loaded before we click.
+  await residueDataReady;
 
   // Drive the map to an almond field and dispatch a click on it. Returns diagnostics.
   const result = await page.evaluate(async () => {
@@ -138,8 +151,10 @@ test('LandIQ crop field popup uses aggregate totals + collapsible sections (issu
   await breakdown.locator('summary').click();
   await expect(breakdown).toContainText(/wet:/i);
   const wetRows = await breakdown.locator(':scope :text("Wet:")').count();
-  // Almonds have several residue resources; at least 2 distinct streams expected.
-  expect(wetRows, 'almond residue breakdown should list multiple residue types').toBeGreaterThanOrEqual(2);
+  // At least one residue stream renders with Wet/Dry. (Not >=2: issue #164 filters
+  // out overlapping "Include In Totals = false" sub-categories, so a given almond
+  // field may legitimately have a single includable residue stream.)
+  expect(wetRows, 'residue breakdown should list at least one residue stream').toBeGreaterThanOrEqual(1);
 
   // Evidence: expanded popup showing the multiple almond residue types.
   await popup.screenshot({ path: 'e2e/__artifacts__/feedstock-popup-153-expanded.png' });
@@ -155,4 +170,16 @@ test('LandIQ crop field popup uses aggregate totals + collapsible sections (issu
   // Sanity: collapsed popup is reasonably short (not a mile tall).
   expect(collapsedBox, 'popup should have a measurable box').not.toBeNull();
   expect(collapsedBox!.height, 'collapsed popup should be compact (< 320px tall)').toBeLessThan(320);
+
+  // Issue #163: the "Composition & seasonal data" section must surface AVERAGED
+  // composition stats for the resources that have lab data (almond shells/hulls),
+  // not come up empty because only the first (data-less) resource was queried.
+  const composition = popup.locator('details', { hasText: 'Composition' });
+  await expect(composition).toHaveCount(1);
+  await composition.locator('summary').click();
+  // Composition is fetched + rendered async after the click; wait for it.
+  await expect(composition).toContainText('Composition (avg)', { timeout: 15_000 });
+  await expect(composition).toContainText(/Moisture:/i);
+  await expect(composition).toContainText(/Lignin:/i);
+  await popup.screenshot({ path: 'e2e/__artifacts__/feedstock-popup-163-composition.png' });
 });

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -15,6 +15,7 @@ import { getAvailability, getAnalysisByResource, getCensusByCrop } from '@/lib/a
 import { getCountyGeoid } from '@/lib/county-lookup';
 import { getApiResource, getUsdaCropName, STATE_GEOID } from '@/lib/resource-mapping';
 import { parseFeatureResources, getResidueFactorsByResourceNames } from '@/lib/resource-residues';
+import { summarizeLeadComposition } from '@/lib/composition-filters';
 import { onResidueDataLoaded, shouldIncludeResidueInTotals } from '@/lib/residue-data';
 import { getCountyAggregateStats } from '@/lib/county-analysis';
 import { formatNumberWithCommas } from '@/lib/utils';
@@ -2834,6 +2835,13 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             const popupResource = featureResources.length > 0
               ? featureResources[0].trim().toLowerCase()
               : apiResource;
+            // Composition is fetched for EVERY residue resource on this field (not
+            // just the first), so multi-residue crops like almonds surface the
+            // streams that actually carry lab data (shells/hulls), not the empty one.
+            const compositionResources = (featureResources.length > 0
+              ? featureResources.map(r => r.trim().toLowerCase())
+              : (apiResource ? [apiResource] : []))
+              .filter((r, i, arr) => r && arr.indexOf(r) === i);
             const usdaCrop = getUsdaCropName(cropName);
             const apiSectionId = `api-data-${Date.now()}`;
 
@@ -2880,10 +2888,10 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             if (popupResource || (countyGeoid && usdaCrop)) {
               (async () => {
                 try {
-                  const [availResult, analysisResult, censusResult] = await Promise.allSettled([
+                  const [availResult, censusResult, ...analysisResults] = await Promise.allSettled([
                     popupResource ? getAvailability(popupResource, STATE_GEOID) : Promise.resolve(null),
-                    popupResource ? getAnalysisByResource(popupResource, STATE_GEOID) : Promise.resolve(null),
                     (usdaCrop && countyGeoid) ? getCensusByCrop(usdaCrop, countyGeoid) : Promise.resolve(null),
+                    ...compositionResources.map(r => getAnalysisByResource(r, STATE_GEOID)),
                   ]);
 
                   const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
@@ -2897,13 +2905,36 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
                     apiHTML += `<div style="margin-bottom:3px;"><strong>Availability:</strong> ${from}–${to}</div>`;
                   }
 
-                  // Analysis: moisture + heating value
-                  const analysis = analysisResult.status === 'fulfilled' ? analysisResult.value : null;
-                  if (analysis && analysis.data && analysis.data.length > 0) {
-                    analysis.data.forEach(item => {
-                      const label = item.parameter.replace(/_/g, ' ').replace(/\w\S*/g, t => t.charAt(0).toUpperCase() + t.substr(1).toLowerCase());
-                      apiHTML += `<div style="margin-bottom:3px;"><strong>${label}:</strong> ${item.value} ${item.unit}</div>`;
-                    });
+                  // Composition: averaged summary stats per residue resource. Each
+                  // resource carries many lab samples; summarizeLeadComposition rolls
+                  // them into one value per headline parameter (moisture, lignin, ash,
+                  // volatile solids, nitrogen, heating value). Resources with no
+                  // analysis data (e.g. "almond woodchips") are skipped.
+                  const shortenUnit = (u) => (u || '')
+                    .replace(/%\s*total weight/i, '%')
+                    .replace(/%\s*dry weight/i, '% dry')
+                    .replace(/^pc$/i, '%')
+                    .trim();
+                  const fmtStat = (s) => {
+                    const rounded = Math.abs(s.value) >= 100 ? Math.round(s.value) : Math.round(s.value * 10) / 10;
+                    const u = shortenUnit(s.unit);
+                    return u.startsWith('%') ? `${rounded}${u}` : `${rounded} ${u}`.trim();
+                  };
+                  let compositionHTML = '';
+                  analysisResults.forEach((res, i) => {
+                    const resp = res.status === 'fulfilled' ? res.value : null;
+                    const stats = summarizeLeadComposition(resp);
+                    if (!stats.length) return;
+                    const resName = compositionResources[i].replace(/\b\w/g, c => c.toUpperCase());
+                    const rows = stats.map(s => `<div style="margin-bottom:1px;">${s.label}: ${fmtStat(s)}</div>`).join('');
+                    compositionHTML += `
+                      <div style="margin-top:4px;">
+                        <div style="font-weight:bold;color:#555;">${resName}</div>
+                        <div style="padding-left:8px;">${rows}</div>
+                      </div>`;
+                  });
+                  if (compositionHTML) {
+                    apiHTML += `<div style="margin-top:4px;font-weight:bold;">Composition (avg)</div>${compositionHTML}`;
                   }
 
                   // Census: harvested acres for county

--- a/src/lib/composition-filters.ts
+++ b/src/lib/composition-filters.ts
@@ -113,6 +113,50 @@ export function parseCompositionData(response: AnalysisListResponse | null): Com
   };
 }
 
+/** A single averaged composition parameter, ready for display. */
+export interface CompositionStat {
+  key: string;
+  label: string;
+  value: number;
+  unit: string;
+  /** Number of underlying lab samples averaged into `value`. */
+  n: number;
+}
+
+// The headline composition parameters surfaced in the map popup, in display
+// order. Matching is loose (lowercased substring / prefix) so it catches the
+// real API names — e.g. "ash solids" and "volatile solids" — which the exact
+// findParam() lookups above intentionally do not.
+const LEAD_COMPOSITION_PARAMS: Array<{ key: string; label: string; match: (p: string) => boolean }> = [
+  { key: 'moisture',       label: 'Moisture',        match: p => p.startsWith('moisture') },
+  { key: 'lignin',         label: 'Lignin',          match: p => p.includes('lignin') },
+  { key: 'ash',            label: 'Ash',             match: p => p.startsWith('ash') },
+  { key: 'volatileSolids', label: 'Volatile solids', match: p => p.includes('volatile') },
+  { key: 'nitrogen',       label: 'Nitrogen',        match: p => p.startsWith('nitrogen') },
+  { key: 'hhv',            label: 'Heating value',   match: p => p.includes('hhv') || p.includes('heating') },
+];
+
+/**
+ * Roll an analysis response (which holds many individual lab samples per
+ * parameter) up into averaged summary stats for the headline composition
+ * parameters. Returns an empty array when the resource has no analysis data.
+ */
+export function summarizeLeadComposition(response: AnalysisListResponse | null): CompositionStat[] {
+  const data = response?.data;
+  if (!data || !data.length) return [];
+
+  const stats: CompositionStat[] = [];
+  for (const spec of LEAD_COMPOSITION_PARAMS) {
+    const samples = data.filter(
+      d => spec.match(d.parameter.toLowerCase()) && d.value != null && !Number.isNaN(Number(d.value))
+    );
+    if (!samples.length) continue;
+    const avg = samples.reduce((sum, d) => sum + Number(d.value), 0) / samples.length;
+    stats.push({ key: spec.key, label: spec.label, value: avg, unit: samples[0].unit ?? '', n: samples.length });
+  }
+  return stats;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------

--- a/tests/composition-summary.test.ts
+++ b/tests/composition-summary.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { summarizeLeadComposition } from '../src/lib/composition-filters';
+import type { AnalysisListResponse } from '../src/lib/api-types';
+
+// Mirrors the real analysis API shape for "almond shells": many lab samples per
+// parameter, real-world param names ("ash solids", "volatile solids"), and a
+// resource ("almond woodchips") that returns no data at all.
+function resp(data: Array<{ parameter: string; value: number | null; unit: string }>): AnalysisListResponse {
+  return { resource: 'x', geoid: '06000', data } as unknown as AnalysisListResponse;
+}
+
+test('summarizeLeadComposition averages samples per headline parameter', () => {
+  const stats = summarizeLeadComposition(
+    resp([
+      { parameter: 'moisture', value: 11.66, unit: '% total weight' },
+      { parameter: 'moisture', value: 11.73, unit: '% total weight' },
+      { parameter: 'moisture', value: 11.58, unit: '% total weight' },
+      { parameter: 'lignin', value: 29.0, unit: '% dry weight' },
+      { parameter: 'lignin', value: 29.28, unit: '% dry weight' },
+      { parameter: 'ash solids', value: 4.37, unit: '% total weight' },
+      { parameter: 'ash solids', value: 4.51, unit: '% total weight' },
+      { parameter: 'volatile solids', value: 84.0, unit: '% total weight' },
+      { parameter: 'nitrogen', value: 0.7, unit: 'pc' },
+      { parameter: 'ca', value: 69647, unit: 'ppm' }, // not a lead param — excluded
+    ])
+  );
+
+  const byKey = Object.fromEntries(stats.map(s => [s.key, s]));
+
+  // moisture averaged across the 3 samples
+  assert.ok(Math.abs(byKey.moisture.value - 11.6566) < 0.01, 'moisture should be the mean of its samples');
+  assert.equal(byKey.moisture.n, 3);
+  // "ash solids" and "volatile solids" must be matched (exact findParam would miss these)
+  assert.ok(byKey.ash, 'ash should match "ash solids"');
+  assert.ok(byKey.volatileSolids, 'volatile solids should be matched');
+  assert.ok(Math.abs(byKey.lignin.value - 29.14) < 0.01, 'lignin averaged');
+  // elemental params are not surfaced as lead stats
+  assert.equal(stats.find(s => s.key === 'ca'), undefined);
+  assert.equal(stats.find(s => s.label === 'Ca'), undefined);
+});
+
+test('summarizeLeadComposition returns empty array for a resource with no data', () => {
+  assert.deepEqual(summarizeLeadComposition(resp([])), []);
+  assert.deepEqual(summarizeLeadComposition(null), []);
+});
+
+test('summarizeLeadComposition ignores null sample values', () => {
+  const stats = summarizeLeadComposition(
+    resp([
+      { parameter: 'moisture', value: null, unit: '%' },
+      { parameter: 'moisture', value: 10, unit: '%' },
+    ])
+  );
+  assert.equal(stats[0].value, 10, 'null values must not drag the average toward zero');
+  assert.equal(stats[0].n, 1);
+});

--- a/tests/state-geoid.test.ts
+++ b/tests/state-geoid.test.ts
@@ -28,6 +28,9 @@ test('analysis/availability call sites no longer hardcode the bare "06" geoid', 
   assert.doesNotMatch(page, /batchFetchCompositionData\('06'\)/, 'page.tsx should not pin composition fetch to "06"');
 
   const map = read('src/components/Map.js');
-  assert.match(map, /getAnalysisByResource\(popupResource, STATE_GEOID\)/, 'Map popup should query analysis at STATE_GEOID');
+  // Composition is now fetched per residue resource (see #163), so the analysis
+  // call site maps over resources — but it must still pass STATE_GEOID, never "06".
+  assert.match(map, /getAnalysisByResource\([A-Za-z]\w*, STATE_GEOID\)/, 'Map popup should query analysis at STATE_GEOID');
+  assert.doesNotMatch(map, /getAnalysisByResource\([^)]*'06'\)/, 'Map popup analysis must not hardcode the bare "06" geoid');
   assert.match(map, /getAvailability\(popupResource, STATE_GEOID\)/, 'Map popup should query availability at STATE_GEOID');
 });


### PR DESCRIPTION
## Summary

Two related popup-data fixes (folded per request):

### #163 — Composition summary was missing for almonds
The "Crop Field Details" popup only ever queried composition for the **first** residue resource (`featureResources[0]` = `almond woodchips`, which the API returns empty), and dumped every raw lab sample. Now it:
- fetches composition for **all** of the field's residue resources,
- drops the ones with no data,
- shows **averaged** per-resource summary stats — moisture, lignin, ash, volatile solids, nitrogen (heating value if present) — via new `summarizeLeadComposition()`.

### #166 — Residue factors silently loaded "0 items" (live prod regression)
Upstream `resource_info.json` was re-exported with **Title-Case keys** (`"LandIQ Crop Name"`, `"Residue Yield (Wet Ton/Ac)"`…); the snake_case parser skipped every row → "Residue data loaded successfully 0 items" → the entire residue breakdown/totals (and residue inventory + energy features) vanished. `normalizeRawResidueItem()` now reads **both** key conventions.

## Verification
- `npm test` — 161 passed (added `composition-summary` + `residue-data-schema` unit tests; updated `state-geoid` call-site assertion).
- `npm run build` — clean (TypeScript ok).
- Playwright `e2e/tests/feedstock-popup.spec.ts` — passes: clicks an almond field, asserts residue breakdown **and** the averaged composition summary (Moisture/Lignin/…) render; waits for residue data so a fast click can't beat the async load.
- In-browser: almond popup shows residue breakdown + per-resource composition (Almond Shells: Moisture 10.8%, Lignin 29.1% dry, Ash 5%, …).

closes #163
closes #166
