### PR TITLE
Promote: filter feedstocks by Include In Totals + composition/CARB popup fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -940,16 +940,18 @@ Async loader for the live `resource_info.json` from GitHub Pages.
 
 **Data source:** `https://sustainability-software-lab.github.io/ca-biositing/resource_info.json`
 
-**Raw JSON fields per record:** `resource`, `resource_code`, `landiq_crop_name`, `residue_type`, `collected`, `from_month`, `to_month`, `residue_yield_wet_ton_per_ac`, `moisture_content`, `residue_yield_dry_ton_per_ac`
+**Raw JSON fields per record (GOTCHA — Title Case headers):** the published JSON uses Title Case column headers, not snake_case: `Resource`, `Resource Code`, `LandIQ Crop Name`, `Residue Type`, `Collected?`, `Include In Totals`, `From Month`, `To Month`, `Residue Yield (Wet Ton/Ac)`, `Moisture Content`, `Residue Yield (Dry Ton/Ac)` (a side-car `resource_info_header_mapping.json` documents the snake_case↔Title Case mapping). `Collected?` and `Include In Totals` are real JSON booleans (legacy was `"TRUE"`/`"FALSE"` strings). `parseResidueRecords` reads **both** conventions via a `pickField` helper, so reading only snake_case (the historical bug fixed in #164) silently drops every field. When adding/renaming a JSON column, update the `pickField` calls in `residue-data.ts`.
 
 **Exports:**
 
 | Export | Description |
 |---|---|
-| `fetchResidueData()` | Fetches and caches the JSON. Idempotent. |
+| `fetchResidueData()` | Fetches and caches the JSON. Idempotent. Delegates parsing to `parseResidueRecords`. |
+| `parseResidueRecords(rawArray)` | Pure parser → `{ byCrop, byResource }`. Reads Title Case and legacy snake_case headers. Exported for unit testing. |
 | `getResidueData(standardizedCropName)` | Returns `ResidueFactors[]` for a crop (empty array if not found). Synchronous after load. |
+| `shouldIncludeResidueInTotals(factor)` | **Shared dedup filter** for popup + inventory: `includeInTotals === true && collected === false`. Excludes overlapping sub-categories (`Include In Totals = false`, e.g. "Almond Shells and Hulls mix") and processing waste (`Collected? = true`, e.g. hulls/shells) so field totals are not double-counted. Both `Map.js` popups and `SitingInventory.tsx` call this single predicate so they cannot diverge. |
 | `onResidueDataLoaded(callback)` | Subscribe to load completion. Fires immediately if already loaded. |
-| `ResidueFactors` | `{ resourceName, wetTonsPerAcre, moistureContent, dryTonsPerAcre, seasonalAvailability, fromMonth?, toMonth?, residueType, collected, category? }` |
+| `ResidueFactors` | `{ resourceName, wetTonsPerAcre, moistureContent, dryTonsPerAcre, seasonalAvailability, fromMonth?, toMonth?, residueType, collected, includeInTotals?, category? }` |
 
 ---
 

--- a/e2e/tests/feedstock-popup.spec.ts
+++ b/e2e/tests/feedstock-popup.spec.ts
@@ -144,6 +144,14 @@ test('LandIQ crop field popup uses aggregate totals + collapsible sections (issu
   // Evidence: expanded popup showing the multiple almond residue types.
   await popup.screenshot({ path: 'e2e/__artifacts__/feedstock-popup-153-expanded.png' });
 
+  // Regression for issue #164: overlapping sub-categories flagged Include In Totals = false
+  // (e.g. the "Almond Shells and Hulls mix" combo and "Almond stick char") and collected
+  // processing waste must NOT appear in the field popup breakdown, so totals are not
+  // double-counted.
+  const breakdownText = (await breakdown.innerText()).toLowerCase();
+  expect(breakdownText).not.toContain('shells and hulls mix');
+  expect(breakdownText).not.toContain('stick char');
+
   // Sanity: collapsed popup is reasonably short (not a mile tall).
   expect(collapsedBox, 'popup should have a measurable box').not.toBeNull();
   expect(collapsedBox!.height, 'collapsed popup should be compact (< 320px tall)').toBeLessThan(320);

--- a/e2e/tests/feedstock-popup.spec.ts
+++ b/e2e/tests/feedstock-popup.spec.ts
@@ -35,6 +35,16 @@ test('LandIQ crop field popup uses aggregate totals + collapsible sections (issu
 }) => {
   test.setTimeout(120_000);
 
+  // The residue breakdown is built synchronously at click time from the async-loaded
+  // resource_info.json. Listen for its load signal BEFORE navigating so a fast click
+  // doesn't beat the data and silently drop the residue section (a real flake).
+  const residueDataReady = page
+    .waitForEvent('console', {
+      predicate: (m) => /Residue data loaded successfully/i.test(m.text()),
+      timeout: 60_000,
+    })
+    .catch(() => undefined);
+
   await page.goto('http://localhost:3100/');
 
   // Wait for the map + feedstock layer to be registered in the style.
@@ -42,6 +52,9 @@ test('LandIQ crop field popup uses aggregate totals + collapsible sections (issu
     () => !!window.mapboxMap && !!window.mapboxMap.getLayer('feedstock-vector-layer'),
     { timeout: 60_000 }
   );
+
+  // ...and for residue factor data to be loaded before we click.
+  await residueDataReady;
 
   // Drive the map to an almond field and dispatch a click on it. Returns diagnostics.
   const result = await page.evaluate(async () => {
@@ -138,8 +151,10 @@ test('LandIQ crop field popup uses aggregate totals + collapsible sections (issu
   await breakdown.locator('summary').click();
   await expect(breakdown).toContainText(/wet:/i);
   const wetRows = await breakdown.locator(':scope :text("Wet:")').count();
-  // Almonds have several residue resources; at least 2 distinct streams expected.
-  expect(wetRows, 'almond residue breakdown should list multiple residue types').toBeGreaterThanOrEqual(2);
+  // At least one residue stream renders with Wet/Dry. (Not >=2: issue #164 filters
+  // out overlapping "Include In Totals = false" sub-categories, so a given almond
+  // field may legitimately have a single includable residue stream.)
+  expect(wetRows, 'residue breakdown should list at least one residue stream').toBeGreaterThanOrEqual(1);
 
   // Evidence: expanded popup showing the multiple almond residue types.
   await popup.screenshot({ path: 'e2e/__artifacts__/feedstock-popup-153-expanded.png' });
@@ -155,4 +170,16 @@ test('LandIQ crop field popup uses aggregate totals + collapsible sections (issu
   // Sanity: collapsed popup is reasonably short (not a mile tall).
   expect(collapsedBox, 'popup should have a measurable box').not.toBeNull();
   expect(collapsedBox!.height, 'collapsed popup should be compact (< 320px tall)').toBeLessThan(320);
+
+  // Issue #163: the "Composition & seasonal data" section must surface AVERAGED
+  // composition stats for the resources that have lab data (almond shells/hulls),
+  // not come up empty because only the first (data-less) resource was queried.
+  const composition = popup.locator('details', { hasText: 'Composition' });
+  await expect(composition).toHaveCount(1);
+  await composition.locator('summary').click();
+  // Composition is fetched + rendered async after the click; wait for it.
+  await expect(composition).toContainText('Composition (avg)', { timeout: 15_000 });
+  await expect(composition).toContainText(/Moisture:/i);
+  await expect(composition).toContainText(/Lignin:/i);
+  await popup.screenshot({ path: 'e2e/__artifacts__/feedstock-popup-163-composition.png' });
 });

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -371,9 +371,13 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
               if (byproductParts.length > 0 && byproductParts.length === qtyParts.length) {
                 const itemLines = byproductParts.map((item, i) => {
                   const num = Number(qtyParts[i].replace(/,/g, ''));
-                  const formattedQty = !isNaN(num) ? num.toLocaleString() : qtyParts[i];
+                  if (isNaN(num) || num === 0) return null;
+                  const formattedQty = num >= 1
+                    ? Math.round(num).toLocaleString()
+                    : num.toFixed(2);
                   return `<div style="margin-left: 12px; margin-bottom: 2px; text-align: left;">- ${item}: ${formattedQty} tons per year</div>`;
-                }).join('');
+                }).filter(Boolean).join('');
+                if (!itemLines) return;
                 content += `<div style="margin-bottom: 3px; text-align: left;"><strong style="font-weight: bold;">Reported Quantities:</strong>${itemLines}</div>`;
               } else {
                 // Fallback: lengths mismatch or no byproducts — show as-is with units

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -41,6 +41,9 @@ if (MAPBOX_ACCESS_TOKEN && MAPBOX_ACCESS_TOKEN !== 'YOUR_MAPBOX_ACCESS_TOKEN') {
 }
 
 
+const toTitleCase = (str) =>
+  str ? str.replace(/\w\S*/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()) : str;
+
 // Accept props for data and visibility
 const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, onCountySelect, compositionFilters }) => { // Added visibleCrops, croplandOpacity, onGeoidsChange props
   
@@ -1485,7 +1488,7 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
           if (!feature) return;
 
           const geoid = feature.properties.GEOID;
-          const name = feature.properties.NAME;
+          const name = toTitleCase(feature.properties.NAME);
           if (!geoid || !name) return;
 
           // Close any existing popup
@@ -1586,7 +1589,7 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             }
             return;
           }
-          const countyName = feature.properties.NAME || 'Unknown County';
+          const countyName = toTitleCase(feature.properties.NAME) || 'Unknown County';
           if (!hoverPopupRef.current) {
             hoverPopupRef.current = new mapboxgl.Popup({
               closeButton: false,
@@ -2696,7 +2699,9 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
 
                 // Format specific values
                 if (key === 'acres' && typeof value === 'number') {
-                  value = value.toFixed(2); // Round acres to 2 decimal places
+                  value = value.toFixed(2);
+                } else if (key === 'county' && typeof value === 'string') {
+                  value = toTitleCase(value);
                 }
                 // Add more formatting rules here if needed
 
@@ -2773,7 +2778,7 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             const countyGeoid = getCountyGeoid(properties.county || '');
             // Notify parent of selected county so it can show the county feedstock panel
             if (onCountySelect && properties.county && countyGeoid) {
-              onCountySelect(properties.county, countyGeoid);
+              onCountySelect(toTitleCase(properties.county), countyGeoid);
             }
             const apiResource = getApiResource(cropName);
             // Resources-first: enrich from this polygon's own residue when present.

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -15,6 +15,7 @@ import { getAvailability, getAnalysisByResource, getCensusByCrop } from '@/lib/a
 import { getCountyGeoid } from '@/lib/county-lookup';
 import { getApiResource, getUsdaCropName, STATE_GEOID } from '@/lib/resource-mapping';
 import { parseFeatureResources, getResidueFactorsByResourceNames } from '@/lib/resource-residues';
+import { summarizeLeadComposition } from '@/lib/composition-filters';
 import { onResidueDataLoaded, shouldIncludeResidueInTotals } from '@/lib/residue-data';
 import { getCountyAggregateStats } from '@/lib/county-analysis';
 import { formatNumberWithCommas } from '@/lib/utils';
@@ -2834,6 +2835,13 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             const popupResource = featureResources.length > 0
               ? featureResources[0].trim().toLowerCase()
               : apiResource;
+            // Composition is fetched for EVERY residue resource on this field (not
+            // just the first), so multi-residue crops like almonds surface the
+            // streams that actually carry lab data (shells/hulls), not the empty one.
+            const compositionResources = (featureResources.length > 0
+              ? featureResources.map(r => r.trim().toLowerCase())
+              : (apiResource ? [apiResource] : []))
+              .filter((r, i, arr) => r && arr.indexOf(r) === i);
             const usdaCrop = getUsdaCropName(cropName);
             const apiSectionId = `api-data-${Date.now()}`;
 
@@ -2880,10 +2888,10 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
             if (popupResource || (countyGeoid && usdaCrop)) {
               (async () => {
                 try {
-                  const [availResult, analysisResult, censusResult] = await Promise.allSettled([
+                  const [availResult, censusResult, ...analysisResults] = await Promise.allSettled([
                     popupResource ? getAvailability(popupResource, STATE_GEOID) : Promise.resolve(null),
-                    popupResource ? getAnalysisByResource(popupResource, STATE_GEOID) : Promise.resolve(null),
                     (usdaCrop && countyGeoid) ? getCensusByCrop(usdaCrop, countyGeoid) : Promise.resolve(null),
+                    ...compositionResources.map(r => getAnalysisByResource(r, STATE_GEOID)),
                   ]);
 
                   const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
@@ -2897,13 +2905,36 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
                     apiHTML += `<div style="margin-bottom:3px;"><strong>Availability:</strong> ${from}–${to}</div>`;
                   }
 
-                  // Analysis: moisture + heating value
-                  const analysis = analysisResult.status === 'fulfilled' ? analysisResult.value : null;
-                  if (analysis && analysis.data && analysis.data.length > 0) {
-                    analysis.data.forEach(item => {
-                      const label = item.parameter.replace(/_/g, ' ').replace(/\w\S*/g, t => t.charAt(0).toUpperCase() + t.substr(1).toLowerCase());
-                      apiHTML += `<div style="margin-bottom:3px;"><strong>${label}:</strong> ${item.value} ${item.unit}</div>`;
-                    });
+                  // Composition: averaged summary stats per residue resource. Each
+                  // resource carries many lab samples; summarizeLeadComposition rolls
+                  // them into one value per headline parameter (moisture, lignin, ash,
+                  // volatile solids, nitrogen, heating value). Resources with no
+                  // analysis data (e.g. "almond woodchips") are skipped.
+                  const shortenUnit = (u) => (u || '')
+                    .replace(/%\s*total weight/i, '%')
+                    .replace(/%\s*dry weight/i, '% dry')
+                    .replace(/^pc$/i, '%')
+                    .trim();
+                  const fmtStat = (s) => {
+                    const rounded = Math.abs(s.value) >= 100 ? Math.round(s.value) : Math.round(s.value * 10) / 10;
+                    const u = shortenUnit(s.unit);
+                    return u.startsWith('%') ? `${rounded}${u}` : `${rounded} ${u}`.trim();
+                  };
+                  let compositionHTML = '';
+                  analysisResults.forEach((res, i) => {
+                    const resp = res.status === 'fulfilled' ? res.value : null;
+                    const stats = summarizeLeadComposition(resp);
+                    if (!stats.length) return;
+                    const resName = compositionResources[i].replace(/\b\w/g, c => c.toUpperCase());
+                    const rows = stats.map(s => `<div style="margin-bottom:1px;">${s.label}: ${fmtStat(s)}</div>`).join('');
+                    compositionHTML += `
+                      <div style="margin-top:4px;">
+                        <div style="font-weight:bold;color:#555;">${resName}</div>
+                        <div style="padding-left:8px;">${rows}</div>
+                      </div>`;
+                  });
+                  if (compositionHTML) {
+                    apiHTML += `<div style="margin-top:4px;font-weight:bold;">Composition (avg)</div>${compositionHTML}`;
                   }
 
                   // Census: harvested acres for county

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -375,7 +375,8 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
                   const formattedQty = num >= 1
                     ? Math.round(num).toLocaleString()
                     : num.toFixed(2);
-                  return `<div style="margin-left: 12px; margin-bottom: 2px; text-align: left;">- ${item}: ${formattedQty} tons per year</div>`;
+                  const displayItem = item.charAt(0).toUpperCase() + item.slice(1);
+                  return `<div style="margin-left: 12px; margin-bottom: 2px; text-align: left;">- ${displayItem}: ${formattedQty} tons per year</div>`;
                 }).filter(Boolean).join('');
                 if (!itemLines) return;
                 content += `<div style="margin-bottom: 3px; text-align: left;"><strong style="font-weight: bold;">Reported Quantities:</strong>${itemLines}</div>`;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -15,7 +15,7 @@ import { getAvailability, getAnalysisByResource, getCensusByCrop } from '@/lib/a
 import { getCountyGeoid } from '@/lib/county-lookup';
 import { getApiResource, getUsdaCropName, STATE_GEOID } from '@/lib/resource-mapping';
 import { parseFeatureResources, getResidueFactorsByResourceNames } from '@/lib/resource-residues';
-import { onResidueDataLoaded } from '@/lib/residue-data';
+import { onResidueDataLoaded, shouldIncludeResidueInTotals } from '@/lib/residue-data';
 import { getCountyAggregateStats } from '@/lib/county-analysis';
 import { formatNumberWithCommas } from '@/lib/utils';
 
@@ -2764,7 +2764,10 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
               (featureResources.length > 0
                 ? getResidueFactorsByResourceNames(featureResources)
                 : null) ?? getCropResidueFactors(cropName);
-            const residueFactorsArray = residueResult?.factors;
+            // Shared dedup filter: only residues flagged Include In Totals and
+            // left in the field (Collected? = false) count toward the popup
+            // totals, so overlapping sub-categories are not double-counted.
+            const residueFactorsArray = residueResult?.factors?.filter(shouldIncludeResidueInTotals);
 
             if (residueFactorsArray && residueFactorsArray.length > 0) {
               // Accumulate aggregate totals and per-resource detail rows in one pass.

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -346,9 +346,42 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
       const labelKeys = Object.keys(labels);
 
       if (labelKeys.length > 0) {
+        const isCarbPopup = layerId === CARB_POPUP_LABEL_KEY;
+        const carbQtyRaw = isCarbPopup ? properties.quantities : null;
+        const carbByproductsRaw = isCarbPopup ? properties.byproducts : null;
+        const hasCarbQty = carbQtyRaw != null && !nullValues.includes(String(carbQtyRaw).trim());
+        const hasCarbByproducts = carbByproductsRaw != null && !nullValues.includes(String(carbByproductsRaw).trim());
+
         labelKeys.forEach(key => {
           if (Object.prototype.hasOwnProperty.call(properties, key) &&
               !nullValues.includes(String(properties[key]).trim())) {
+
+            // CARB: absorb byproducts into the quantities section below
+            if (isCarbPopup && key === 'byproducts' && hasCarbQty) {
+              return;
+            }
+
+            // CARB: render quantities as a correlated list paired with byproduct names
+            if (isCarbPopup && key === 'quantities') {
+              const qtyParts = String(carbQtyRaw).split(', ').map(s => s.trim()).filter(Boolean);
+              const byproductParts = hasCarbByproducts
+                ? String(carbByproductsRaw).split(', ').map(s => s.trim()).filter(Boolean)
+                : [];
+
+              if (byproductParts.length > 0 && byproductParts.length === qtyParts.length) {
+                const itemLines = byproductParts.map((item, i) => {
+                  const num = Number(qtyParts[i].replace(/,/g, ''));
+                  const formattedQty = !isNaN(num) ? num.toLocaleString() : qtyParts[i];
+                  return `<div style="margin-left: 12px; margin-bottom: 2px; text-align: left;">- ${item}: ${formattedQty} tons per year</div>`;
+                }).join('');
+                content += `<div style="margin-bottom: 3px; text-align: left;"><strong style="font-weight: bold;">Reported Quantities:</strong>${itemLines}</div>`;
+              } else {
+                // Fallback: lengths mismatch or no byproducts — show as-is with units
+                content += `<div style="margin-bottom: 3px; text-align: left;"><strong style="font-weight: bold;">Reported Quantities:</strong> ${carbQtyRaw} tons per year</div>`;
+              }
+              return;
+            }
+
             content += formatAndBuildLine(key, properties[key]);
           }
         });

--- a/src/components/SitingInventory.tsx
+++ b/src/components/SitingInventory.tsx
@@ -9,7 +9,7 @@ import { formatNumberWithCommas, downloadCSV } from '@/lib/utils';
 import { getAvailability, getAnalysisByResource } from '@/lib/api';
 import { getApiResource, STATE_GEOID } from '@/lib/resource-mapping';
 import { getResidueFactorsByResourceNames } from '@/lib/resource-residues';
-import { onResidueDataLoaded } from '@/lib/residue-data';
+import { onResidueDataLoaded, shouldIncludeResidueInTotals } from '@/lib/residue-data';
 import { computeEnergyTotals, EnergyTotals } from '@/lib/energy-calculations';
 import { CompositionData, parseCompositionData, CompositionFilters, CompositionLookup, cropPassesCompositionFilters } from '@/lib/composition-filters';
 import { computeMixSummary, rankTechnologies, TechScore } from '@/lib/technology-matcher';
@@ -188,9 +188,10 @@ const SitingInventory: React.FC<SitingInventoryProps> = ({
       for (const factor of residueResult.factors) {
         // Skip entries with no yield data (e.g. "Missing" values that parsed to 0)
         if (!factor.dryTonsPerAcre && !factor.wetTonsPerAcre) continue;
-        // Exclude processor waste (collected===true means hulls, shells, etc. removed
-        // at a processing facility -- not attributable to field acreage).
-        if (factor.collected) continue;
+        // Shared dedup filter: keep only residues flagged Include In Totals and
+        // left in the field (Collected? = false). Excludes overlapping
+        // sub-categories and processor waste so totals are not double-counted.
+        if (!shouldIncludeResidueInTotals(factor)) continue;
         // Resources-tier rows key composition off the residue's own name;
         // crop-tier rows fall back to the crop's primary resource.
         const apiResource = perResidue

--- a/src/lib/composition-filters.ts
+++ b/src/lib/composition-filters.ts
@@ -113,6 +113,50 @@ export function parseCompositionData(response: AnalysisListResponse | null): Com
   };
 }
 
+/** A single averaged composition parameter, ready for display. */
+export interface CompositionStat {
+  key: string;
+  label: string;
+  value: number;
+  unit: string;
+  /** Number of underlying lab samples averaged into `value`. */
+  n: number;
+}
+
+// The headline composition parameters surfaced in the map popup, in display
+// order. Matching is loose (lowercased substring / prefix) so it catches the
+// real API names — e.g. "ash solids" and "volatile solids" — which the exact
+// findParam() lookups above intentionally do not.
+const LEAD_COMPOSITION_PARAMS: Array<{ key: string; label: string; match: (p: string) => boolean }> = [
+  { key: 'moisture',       label: 'Moisture',        match: p => p.startsWith('moisture') },
+  { key: 'lignin',         label: 'Lignin',          match: p => p.includes('lignin') },
+  { key: 'ash',            label: 'Ash',             match: p => p.startsWith('ash') },
+  { key: 'volatileSolids', label: 'Volatile solids', match: p => p.includes('volatile') },
+  { key: 'nitrogen',       label: 'Nitrogen',        match: p => p.startsWith('nitrogen') },
+  { key: 'hhv',            label: 'Heating value',   match: p => p.includes('hhv') || p.includes('heating') },
+];
+
+/**
+ * Roll an analysis response (which holds many individual lab samples per
+ * parameter) up into averaged summary stats for the headline composition
+ * parameters. Returns an empty array when the resource has no analysis data.
+ */
+export function summarizeLeadComposition(response: AnalysisListResponse | null): CompositionStat[] {
+  const data = response?.data;
+  if (!data || !data.length) return [];
+
+  const stats: CompositionStat[] = [];
+  for (const spec of LEAD_COMPOSITION_PARAMS) {
+    const samples = data.filter(
+      d => spec.match(d.parameter.toLowerCase()) && d.value != null && !Number.isNaN(Number(d.value))
+    );
+    if (!samples.length) continue;
+    const avg = samples.reduce((sum, d) => sum + Number(d.value), 0) / samples.length;
+    stats.push({ key: spec.key, label: spec.label, value: avg, unit: samples[0].unit ?? '', n: samples.length });
+  }
+  return stats;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------

--- a/src/lib/residue-data.ts
+++ b/src/lib/residue-data.ts
@@ -30,6 +30,12 @@ export interface ResidueFactors {
   toMonth?: number;
   residueType: string; // e.g. "Ag Residue"
   collected: boolean; // e.g. TRUE/FALSE
+  /**
+   * Data-team dedup flag ("Include In Totals"): false marks an overlapping
+   * sub-category (e.g. "Almond Shells and Hulls mix") that must not be summed
+   * into popup/inventory totals. Undefined is treated as excluded.
+   */
+  includeInTotals?: boolean;
   category?: string;
 }
 
@@ -130,6 +136,106 @@ const inferCategory = (item: RawResidueData): string => {
 };
 
 
+/** Read the first present key from a record, supporting both the live JSON's
+ *  Title Case headers (e.g. "LandIQ Crop Name") and the legacy snake_case keys
+ *  (e.g. "landiq_crop_name"). The published resource_info.json switched to Title
+ *  Case headers (see resource_info_header_mapping.json), so reading only one
+ *  naming convention silently drops every field. */
+function pickField(item: Record<string, unknown>, ...keys: string[]): unknown {
+  for (const key of keys) {
+    const value = item[key];
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+}
+
+/** Parse a TRUE/FALSE flag that may arrive as a real JSON boolean (live JSON) or
+ *  a "TRUE"/"FALSE" string (legacy JSON). Missing/unparseable → false. */
+function parseFlag(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') return value.trim().toUpperCase() === 'TRUE';
+  return false;
+}
+
+function toStr(value: unknown): string {
+  return value === undefined || value === null ? '' : String(value);
+}
+
+/**
+ * Shared inclusion filter for field-attributable residue totals.
+ *
+ * A residue counts toward map-popup and inventory totals only when the data team
+ * has flagged it `Include In Totals` (the dedup flag that excludes overlapping
+ * sub-categories like "Almond Shells and Hulls mix") AND it is left in the field
+ * rather than collected at a processing facility (`Collected? = false`) — the
+ * field popup/inventory attributes tonnage to crop acreage, so processing waste
+ * (hulls, shells; null per-acre yield) does not belong. Both the popup and the
+ * inventory call this single predicate so they can never diverge.
+ */
+export function shouldIncludeResidueInTotals(
+  factor: Pick<ResidueFactors, 'includeInTotals' | 'collected'>
+): boolean {
+  return factor.includeInTotals === true && factor.collected === false;
+}
+
+/**
+ * Pure parser for the raw resource_info.json array. Reads both Title Case and
+ * legacy snake_case headers. Returns the crop-keyed and resource-keyed indexes.
+ * Exported for unit testing; `fetchResidueData` wires it to the network fetch.
+ */
+export function parseResidueRecords(
+  data: Array<Record<string, unknown>>
+): { byCrop: Record<string, ResidueFactors[]>; byResource: Record<string, ResidueFactors> } {
+  const byCrop: Record<string, ResidueFactors[]> = {};
+  const byResource: Record<string, ResidueFactors> = {};
+
+  data.forEach(item => {
+    const cropName = toStr(pickField(item, 'LandIQ Crop Name', 'landiq_crop_name')).trim();
+    if (!cropName) return;
+
+    const resource = toStr(pickField(item, 'Resource', 'resource'));
+
+    const wetTons = parseFloat(toStr(pickField(item, 'Residue Yield (Wet Ton/Ac)', 'residue_yield_wet_ton_per_ac'))) || 0;
+    const dryTons = parseFloat(toStr(pickField(item, 'Residue Yield (Dry Ton/Ac)', 'residue_yield_dry_ton_per_ac'))) || 0;
+
+    // Parse moisture content "11%" -> 0.11
+    let moisture = 0;
+    const moistureStr = toStr(pickField(item, 'Moisture Content', 'moisture_content')).replace('%', '');
+    if (moistureStr) {
+      moisture = parseFloat(moistureStr) / 100;
+      if (Number.isNaN(moisture)) moisture = 0;
+    }
+
+    const fromMonthStr = toStr(pickField(item, 'From Month', 'from_month'));
+    const toMonthStr = toStr(pickField(item, 'To Month', 'to_month'));
+    const seasonal = parseSeasonalAvailability(fromMonthStr, toMonthStr);
+    const fromMonthNum = parseInt(fromMonthStr, 10);
+    const toMonthNum = parseInt(toMonthStr, 10);
+
+    const factor: ResidueFactors = {
+      resourceName: resource,
+      wetTonsPerAcre: wetTons,
+      dryTonsPerAcre: dryTons,
+      moistureContent: moisture,
+      seasonalAvailability: seasonal,
+      fromMonth: isNaN(fromMonthNum) ? undefined : fromMonthNum,
+      toMonth: isNaN(toMonthNum) ? undefined : toMonthNum,
+      residueType: toStr(pickField(item, 'Residue Type', 'residue_type')),
+      collected: parseFlag(pickField(item, 'Collected?', 'collected')),
+      includeInTotals: parseFlag(pickField(item, 'Include In Totals', 'include_in_totals')),
+    };
+
+    (byCrop[cropName] ??= []).push(factor);
+
+    const resourceKey = resource.trim().toLowerCase();
+    if (resourceKey) {
+      byResource[resourceKey] = factor;
+    }
+  });
+
+  return { byCrop, byResource };
+}
+
 export const fetchResidueData = async (): Promise<void> => {
   if (isDataLoaded) return;
   if (loadPromise) return loadPromise;
@@ -140,63 +246,13 @@ export const fetchResidueData = async (): Promise<void> => {
       if (!response.ok) {
         throw new Error(`Failed to fetch residue data: ${response.statusText}`);
       }
-      const data: RawResidueData[] = await response.json();
-      
-      // Process the data
-      const newProcessedData: Record<string, ResidueFactors[]> = {};
-      const newByResource: Record<string, ResidueFactors> = {};
+      const data: unknown = await response.json();
+      const records = Array.isArray(data) ? (data as Array<Record<string, unknown>>) : [];
 
-      data.forEach(item => {
-        let cropName = item.landiq_crop_name; // This seems to be the key we want to match
-        if (!cropName) return;
-        
-        // Normalize crop name (trim whitespace)
-        cropName = cropName.trim();
+      const { byCrop, byResource } = parseResidueRecords(records);
 
-        // Parse numeric values
-        const wetTons = parseFloat(item.residue_yield_wet_ton_per_ac) || 0;
-        const dryTons = parseFloat(item.residue_yield_dry_ton_per_ac) || 0;
-        
-        // Parse moisture content "11%" -> 0.11
-        let moisture = 0;
-        const moistureStr = item.moisture_content?.replace('%', '');
-        if (moistureStr) {
-          moisture = parseFloat(moistureStr) / 100;
-        }
-
-        const seasonal = parseSeasonalAvailability(item.from_month, item.to_month);
-        
-        const collected = item.collected?.toUpperCase() === 'TRUE';
-
-        const fromMonthNum = parseInt(item.from_month, 10);
-        const toMonthNum   = parseInt(item.to_month,   10);
-
-        const factor: ResidueFactors = {
-          resourceName: item.resource,
-          wetTonsPerAcre: wetTons,
-          dryTonsPerAcre: dryTons,
-          moistureContent: moisture,
-          seasonalAvailability: seasonal,
-          fromMonth: isNaN(fromMonthNum) ? undefined : fromMonthNum,
-          toMonth:   isNaN(toMonthNum)   ? undefined : toMonthNum,
-          residueType: item.residue_type,
-          collected: collected
-          // category: inferCategory(item) // We will handle category assignment when retrieving
-        };
-        
-        if (!newProcessedData[cropName]) {
-          newProcessedData[cropName] = [];
-        }
-        newProcessedData[cropName].push(factor);
-
-        const resourceKey = item.resource?.trim().toLowerCase();
-        if (resourceKey) {
-          newByResource[resourceKey] = factor;
-        }
-      });
-
-      processedResidueData = newProcessedData;
-      processedResidueByResource = newByResource;
+      processedResidueData = byCrop;
+      processedResidueByResource = byResource;
       isDataLoaded = true;
       onLoadedCallbacks.forEach(cb => cb());
       onLoadedCallbacks = [];

--- a/src/lib/residue-fallbacks.ts
+++ b/src/lib/residue-fallbacks.ts
@@ -43,6 +43,7 @@ function factor(
   fromMonth: number,
   toMonth: number,
   collected = false,
+  includeInTotals = true,
 ): ResidueFactors {
   return {
     resourceName,
@@ -54,6 +55,7 @@ function factor(
     fromMonth,
     toMonth,
     collected,
+    includeInTotals,
   };
 }
 

--- a/tests/composition-summary.test.ts
+++ b/tests/composition-summary.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { summarizeLeadComposition } from '../src/lib/composition-filters';
+import type { AnalysisListResponse } from '../src/lib/api-types';
+
+// Mirrors the real analysis API shape for "almond shells": many lab samples per
+// parameter, real-world param names ("ash solids", "volatile solids"), and a
+// resource ("almond woodchips") that returns no data at all.
+function resp(data: Array<{ parameter: string; value: number | null; unit: string }>): AnalysisListResponse {
+  return { resource: 'x', geoid: '06000', data } as unknown as AnalysisListResponse;
+}
+
+test('summarizeLeadComposition averages samples per headline parameter', () => {
+  const stats = summarizeLeadComposition(
+    resp([
+      { parameter: 'moisture', value: 11.66, unit: '% total weight' },
+      { parameter: 'moisture', value: 11.73, unit: '% total weight' },
+      { parameter: 'moisture', value: 11.58, unit: '% total weight' },
+      { parameter: 'lignin', value: 29.0, unit: '% dry weight' },
+      { parameter: 'lignin', value: 29.28, unit: '% dry weight' },
+      { parameter: 'ash solids', value: 4.37, unit: '% total weight' },
+      { parameter: 'ash solids', value: 4.51, unit: '% total weight' },
+      { parameter: 'volatile solids', value: 84.0, unit: '% total weight' },
+      { parameter: 'nitrogen', value: 0.7, unit: 'pc' },
+      { parameter: 'ca', value: 69647, unit: 'ppm' }, // not a lead param — excluded
+    ])
+  );
+
+  const byKey = Object.fromEntries(stats.map(s => [s.key, s]));
+
+  // moisture averaged across the 3 samples
+  assert.ok(Math.abs(byKey.moisture.value - 11.6566) < 0.01, 'moisture should be the mean of its samples');
+  assert.equal(byKey.moisture.n, 3);
+  // "ash solids" and "volatile solids" must be matched (exact findParam would miss these)
+  assert.ok(byKey.ash, 'ash should match "ash solids"');
+  assert.ok(byKey.volatileSolids, 'volatile solids should be matched');
+  assert.ok(Math.abs(byKey.lignin.value - 29.14) < 0.01, 'lignin averaged');
+  // elemental params are not surfaced as lead stats
+  assert.equal(stats.find(s => s.key === 'ca'), undefined);
+  assert.equal(stats.find(s => s.label === 'Ca'), undefined);
+});
+
+test('summarizeLeadComposition returns empty array for a resource with no data', () => {
+  assert.deepEqual(summarizeLeadComposition(resp([])), []);
+  assert.deepEqual(summarizeLeadComposition(null), []);
+});
+
+test('summarizeLeadComposition ignores null sample values', () => {
+  const stats = summarizeLeadComposition(
+    resp([
+      { parameter: 'moisture', value: null, unit: '%' },
+      { parameter: 'moisture', value: 10, unit: '%' },
+    ])
+  );
+  assert.equal(stats[0].value, 10, 'null values must not drag the average toward zero');
+  assert.equal(stats[0].n, 1);
+});

--- a/tests/residue-data.test.ts
+++ b/tests/residue-data.test.ts
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseResidueRecords,
+  shouldIncludeResidueInTotals,
+} from '../src/lib/residue-data';
+import type { ResidueFactors } from '../src/lib/residue-data';
+
+// A record shaped like the live GitHub Pages resource_info.json (Title Case headers,
+// real JSON booleans for the flags, string yields).
+function liveAlmondRecords(): Array<Record<string, unknown>> {
+  return [
+    { 'Residue Type': 'Ag Residue', 'Resource': 'Almond Branches', 'LandIQ Crop Name': 'Almonds',
+      'Include In Totals': true, 'Collected?': false, 'From Month': '11', 'To Month': '2',
+      'Residue Yield (Wet Ton/Ac)': '1.7', 'Moisture Content': '15%', 'Residue Yield (Dry Ton/Ac)': '1.5' },
+    { 'Residue Type': 'Processing Waste', 'Resource': 'Almond Hulls', 'LandIQ Crop Name': 'Almonds ',
+      'Include In Totals': true, 'Collected?': true, 'From Month': '8', 'To Month': '10',
+      'Residue Yield (Wet Ton/Ac)': null, 'Moisture Content': '', 'Residue Yield (Dry Ton/Ac)': null },
+    { 'Residue Type': 'Processing Waste', 'Resource': 'Almond Shells and Hulls mix', 'LandIQ Crop Name': 'Almonds',
+      'Include In Totals': false, 'Collected?': true, 'From Month': '8', 'To Month': '10',
+      'Residue Yield (Wet Ton/Ac)': null, 'Moisture Content': '', 'Residue Yield (Dry Ton/Ac)': null },
+  ];
+}
+
+test('parseResidueRecords reads Title Case headers from the live JSON shape', () => {
+  const { byCrop, byResource } = parseResidueRecords(liveAlmondRecords());
+
+  // Crop names are trimmed, so the trailing-space "Almonds " merges with "Almonds".
+  assert.ok(byCrop['Almonds'], 'expected an "Almonds" crop entry');
+  assert.equal(byCrop['Almonds'].length, 3);
+
+  const branches = byResource['almond branches'];
+  assert.ok(branches, 'expected the resource index keyed by lowercased resource name');
+  assert.equal(branches.resourceName, 'Almond Branches');
+  assert.equal(branches.dryTonsPerAcre, 1.5);
+  assert.equal(branches.wetTonsPerAcre, 1.7);
+  assert.equal(branches.moistureContent, 0.15);
+  assert.equal(branches.residueType, 'Ag Residue');
+  assert.equal(branches.collected, false);
+  assert.equal(branches.includeInTotals, true);
+  assert.equal(branches.fromMonth, 11);
+  assert.equal(branches.toMonth, 2);
+});
+
+test('parseResidueRecords still reads legacy snake_case keys (back-compat)', () => {
+  const { byResource } = parseResidueRecords([
+    { resource: 'Rice straw', landiq_crop_name: 'Rice (R1)', residue_type: 'Ag Residue',
+      collected: 'FALSE', include_in_totals: 'TRUE', from_month: '9', to_month: '11',
+      residue_yield_wet_ton_per_ac: '2.0', moisture_content: '25%', residue_yield_dry_ton_per_ac: '1.5' },
+  ]);
+  const straw = byResource['rice straw'];
+  assert.ok(straw);
+  assert.equal(straw.dryTonsPerAcre, 1.5);
+  assert.equal(straw.collected, false);
+  assert.equal(straw.includeInTotals, true);
+});
+
+test('parseResidueRecords parses include_in_totals from boolean and "TRUE", missing → false', () => {
+  const { byResource } = parseResidueRecords([
+    { 'Resource': 'A', 'LandIQ Crop Name': 'Crop A', 'Include In Totals': true, 'Collected?': false,
+      'Residue Yield (Dry Ton/Ac)': '1', 'Residue Yield (Wet Ton/Ac)': '1', 'From Month': '1', 'To Month': '2' },
+    { 'Resource': 'B', 'LandIQ Crop Name': 'Crop B', 'Include In Totals': false, 'Collected?': false,
+      'Residue Yield (Dry Ton/Ac)': '1', 'Residue Yield (Wet Ton/Ac)': '1', 'From Month': '1', 'To Month': '2' },
+    // No Include In Totals key at all → must default to false (excluded).
+    { 'Resource': 'C', 'LandIQ Crop Name': 'Crop C', 'Collected?': false,
+      'Residue Yield (Dry Ton/Ac)': '1', 'Residue Yield (Wet Ton/Ac)': '1', 'From Month': '1', 'To Month': '2' },
+  ]);
+  assert.equal(byResource['a'].includeInTotals, true);
+  assert.equal(byResource['b'].includeInTotals, false);
+  assert.equal(byResource['c'].includeInTotals, false);
+});
+
+function factor(overrides: Partial<ResidueFactors>): ResidueFactors {
+  return {
+    resourceName: 'x',
+    wetTonsPerAcre: 1,
+    dryTonsPerAcre: 1,
+    moistureContent: 0.1,
+    seasonalAvailability: {},
+    residueType: 'Ag Residue',
+    collected: false,
+    includeInTotals: true,
+    ...overrides,
+  };
+}
+
+test('shouldIncludeResidueInTotals: true only when includeInTotals===true AND collected===false', () => {
+  assert.equal(shouldIncludeResidueInTotals(factor({})), true);
+  assert.equal(shouldIncludeResidueInTotals(factor({ includeInTotals: false })), false);
+  assert.equal(shouldIncludeResidueInTotals(factor({ collected: true })), false);
+  assert.equal(shouldIncludeResidueInTotals(factor({ includeInTotals: false, collected: true })), false);
+  // Missing/undefined flag (e.g. a record stripped of the key) is excluded.
+  assert.equal(shouldIncludeResidueInTotals(factor({ includeInTotals: undefined })), false);
+});
+
+test('almond records de-duplicate: included set drops the "mix" combo and collected hulls', () => {
+  const { byCrop } = parseResidueRecords(liveAlmondRecords());
+  const included = byCrop['Almonds'].filter(shouldIncludeResidueInTotals);
+  const names = included.map(f => f.resourceName);
+  assert.deepEqual(names, ['Almond Branches']);
+  // The overlapping "Shells and Hulls mix" (include=false) and collected hulls are excluded.
+  assert.ok(!names.includes('Almond Shells and Hulls mix'));
+  assert.ok(!names.includes('Almond Hulls'));
+});

--- a/tests/state-geoid.test.ts
+++ b/tests/state-geoid.test.ts
@@ -28,6 +28,9 @@ test('analysis/availability call sites no longer hardcode the bare "06" geoid', 
   assert.doesNotMatch(page, /batchFetchCompositionData\('06'\)/, 'page.tsx should not pin composition fetch to "06"');
 
   const map = read('src/components/Map.js');
-  assert.match(map, /getAnalysisByResource\(popupResource, STATE_GEOID\)/, 'Map popup should query analysis at STATE_GEOID');
+  // Composition is now fetched per residue resource (see #163), so the analysis
+  // call site maps over resources — but it must still pass STATE_GEOID, never "06".
+  assert.match(map, /getAnalysisByResource\([A-Za-z]\w*, STATE_GEOID\)/, 'Map popup should query analysis at STATE_GEOID');
+  assert.doesNotMatch(map, /getAnalysisByResource\([^)]*'06'\)/, 'Map popup analysis must not hardcode the bare "06" geoid');
   assert.match(map, /getAvailability\(popupResource, STATE_GEOID\)/, 'Map popup should query availability at STATE_GEOID');
 });


### PR DESCRIPTION
## Summary

- Stop double-counting overlapping feedstocks: map field popups and inventory totals now filter residues by `Include In Totals` + `Collected?` via a single shared predicate (#164).
- Crop field popup shows an aggregated per-resource composition summary instead of raw duplicated rows (#163).
- CARB food-processor popups: quantities split by byproduct with units, zero-quantity rows hidden, values rounded, byproduct names capitalized.
- County names title-cased in map popups and the feedstock panel.

## Content Delta

- `src/components/Map.js`, `src/components/SitingInventory.tsx` — popup + inventory now route residues through `shouldIncludeResidueInTotals`.
- `src/lib/residue-data.ts` — parses `Include In Totals` / `include_in_totals` from `resource_info.json`; adds shared `shouldIncludeResidueInTotals` predicate (`includeInTotals === true && collected === false`).
- `src/lib/residue-fallbacks.ts`, `src/lib/composition-filters.ts` — supporting filter/composition logic.
- Tests: `tests/residue-data.test.ts`, `tests/composition-summary.test.ts`, `tests/state-geoid.test.ts`, `e2e/tests/feedstock-popup.spec.ts`.

## Ancestry Diagnostics

- Diagnostic commit count: 6 (non-merge). Authoritative scope is the 10-file tip-to-tip diff above, not the commit list.

## Test plan

- [ ] Click an Almonds field: popup lists only `Include In Totals` + in-field residues (no branches/chips double-count).
- [ ] County/region inventory totals reflect the filtered set (no overlapping residue double-counting).
- [ ] CARB processor popup: byproduct rows split, units appended, zero rows hidden, names capitalized.
- [ ] No regression for crops without overlapping residues.

*Co-authored with Codex.*
