### PR TITLE
fix(popup): cap LandIQ/facility popup height at 50vh with scroll

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -410,8 +410,8 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
     }
 
     const popupHTML = `
-      <div style="padding: 5px 15px 5px 5px; font-size: 0.9em;">
-        <h4 style="font-size: 1.1em; font-weight: bold; margin: 0 0 8px 0; padding: 0; text-align: left;">${popupTitle}</h4>
+      <div style="padding: 5px 15px 5px 5px; font-size: 0.9em; max-height: 50vh; overflow-y: auto; overflow-x: hidden;">
+        <h4 style="font-size: 1.1em; font-weight: bold; margin: 0 0 8px 0; padding: 0; text-align: left; position: sticky; top: 0; background: #fff; z-index: 1;">${popupTitle}</h4>
         ${content}
       </div>
     `;


### PR DESCRIPTION
## Summary
- Popup content divs in `createPopupForFeature` now have `max-height: 50vh; overflow-y: auto` — prevents the popup from growing taller than half the viewport
- Popup title (`h4`) is `position: sticky; top: 0` so it stays visible as the user scrolls through long content
- Matches the existing pattern already used for county popups (line 1591)

## Test plan
- [ ] Click a LandIQ crop polygon with many composition/residue sections — popup should cap at ~50% of the screen height and be scrollable
- [ ] Title remains pinned at top while scrolling
- [ ] Short popups (few fields) still look normal — no unwanted scrollbar
- [ ] County popup behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)