### PR TITLE
fix(popup): constrain facility popup height via CSS class (bulletproof)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -151,6 +151,14 @@
   /* border-radius: 50%; */
 }
 
+/* Facility / LandIQ popup — cap height and enable scroll */
+.facility-popup .mapboxgl-popup-content {
+  max-height: 50vh !important;
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
+  padding: 10px !important;
+}
+
 /* County-name hover tooltip */
 .county-hover-popup {
   pointer-events: none;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -410,8 +410,8 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
     }
 
     const popupHTML = `
-      <div style="padding: 5px 15px 5px 5px; font-size: 0.9em; max-height: 50vh; overflow-y: auto; overflow-x: hidden;">
-        <h4 style="font-size: 1.1em; font-weight: bold; margin: 0 0 8px 0; padding: 0; text-align: left; position: sticky; top: 0; background: #fff; z-index: 1;">${popupTitle}</h4>
+      <div style="padding: 5px 10px 5px 5px; font-size: 0.9em;">
+        <h4 style="font-size: 1.1em; font-weight: bold; margin: 0 0 8px 0; padding: 4px 0; text-align: left; position: sticky; top: -10px; background: #fff; z-index: 1;">${popupTitle}</h4>
         ${content}
       </div>
     `;


### PR DESCRIPTION
## Problem
Inline `max-height` on the inner div wasn't reliable — Mapbox's `.mapboxgl-popup-content` wrapper could still expand.

## Fix
- Added `.facility-popup .mapboxgl-popup-content { max-height: 50vh !important; overflow-y: auto !important; }` to `globals.css` — constrains the Mapbox wrapper directly, which is the scrolling container
- Title `h4` uses `position: sticky; top: -10px` (offsets the 10px padding on the Mapbox content wrapper) so it stays pinned while scrolling

## Test plan
- [ ] Click a LandIQ polygon with many sections — popup caps at ~50% screen height and scrolls
- [ ] Title stays pinned at top during scroll
- [ ] Short popups unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)