### PR TITLE
Promote: fix(popup): constrain facility popup height via CSS

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -151,6 +151,14 @@
   /* border-radius: 50%; */
 }
 
+/* Facility / LandIQ popup — cap height and enable scroll */
+.facility-popup .mapboxgl-popup-content {
+  max-height: 50vh !important;
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
+  padding: 10px !important;
+}
+
 /* County-name hover tooltip */
 .county-hover-popup {
   pointer-events: none;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -410,8 +410,8 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
     }
 
     const popupHTML = `
-      <div style="padding: 5px 15px 5px 5px; font-size: 0.9em; max-height: 50vh; overflow-y: auto; overflow-x: hidden;">
-        <h4 style="font-size: 1.1em; font-weight: bold; margin: 0 0 8px 0; padding: 0; text-align: left; position: sticky; top: 0; background: #fff; z-index: 1;">${popupTitle}</h4>
+      <div style="padding: 5px 10px 5px 5px; font-size: 0.9em;">
+        <h4 style="font-size: 1.1em; font-weight: bold; margin: 0 0 8px 0; padding: 4px 0; text-align: left; position: sticky; top: -10px; background: #fff; z-index: 1;">${popupTitle}</h4>
         ${content}
       </div>
     `;


### PR DESCRIPTION
Promoting staging to main. Popup height capped at 50vh via CSS on .mapboxgl-popup-content.