### PR TITLE
fix(popup): target crop-residue-popup class for 50vh scroll cap

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -151,8 +151,9 @@
   /* border-radius: 50%; */
 }
 
-/* Facility / LandIQ popup — cap height and enable scroll */
-.facility-popup .mapboxgl-popup-content {
+/* All map popups — cap height and enable scroll */
+.facility-popup .mapboxgl-popup-content,
+.crop-residue-popup .mapboxgl-popup-content {
   max-height: 50vh !important;
   overflow-y: auto !important;
   overflow-x: hidden !important;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -2852,8 +2852,8 @@ const Map = ({ layerVisibility, visibleCrops, croplandOpacity, onGeoidsChange, o
 
             // Increase right padding for close button spacing, remove table
             const popupHTML = `
-              <div style="padding: 5px 15px 5px 5px; font-size: 0.9em;">
-                <h4 style="font-size: 1.1em; font-weight: bold; margin: 0 0 8px 0; padding: 0; text-align: left;">Crop Field Details</h4>
+              <div style="padding: 5px 10px 5px 5px; font-size: 0.9em;">
+                <h4 style="font-size: 1.1em; font-weight: bold; margin: 0 0 8px 0; padding: 4px 0; text-align: left; position: sticky; top: -10px; background: #fff; z-index: 1;">Crop Field Details</h4>
                 ${contentLines}
                 ${residueSection}
                 ${apiLoadingHTML}


### PR DESCRIPTION
Previous fix targeted .facility-popup but the LandIQ crop field popup uses .crop-residue-popup. Both classes now share the same max-height:50vh rule in globals.css.